### PR TITLE
240629 코드 개선 2차

### DIFF
--- a/src/components/CubeRewardsModal.tsx
+++ b/src/components/CubeRewardsModal.tsx
@@ -4,19 +4,19 @@ import { MdArrowForward } from "@react-icons/all-files/md/MdArrowForward";
 import { useState } from "react";
 
 import useCubeReward from "@core/hooks/queries/character/useCubeReward";
-import type { CharacterType } from "@core/types/character";
+import type { Character } from "@core/types/character";
 
 import Modal from "@components/Modal";
 
 interface Props {
-  character: CharacterType;
+  character: Character;
   isOpen: boolean;
   onClose(): void;
 }
 
 const CUBE_NAME_LIST = ["1금제", "2금제", "3금제", "4금제", "5금제"] as const;
 
-const getCubeName = (character: CharacterType) => {
+const getCubeName = (character: Character) => {
   if (character.itemLevel < 1490.0) {
     return "1금제";
   }

--- a/src/components/SortCharacters/Item.tsx
+++ b/src/components/SortCharacters/Item.tsx
@@ -1,13 +1,13 @@
 import styled from "@emotion/styled";
 import React, { forwardRef } from "react";
 
-import { CharacterType } from "@core/types/character";
+import { Character } from "@core/types/character";
 
 interface Props extends React.HTMLAttributes<HTMLDivElement> {
   withOpacity?: boolean;
   isDragging?: boolean;
   style?: React.CSSProperties;
-  character: CharacterType;
+  character: Character;
 }
 
 const Item = forwardRef<HTMLDivElement, Props>(
@@ -36,7 +36,7 @@ Item.displayName = "Item";
 export default Item;
 
 const Wrapper = styled.div<{
-  character: CharacterType;
+  character: Character;
   isDragging: boolean;
   withOpacity: boolean;
 }>`

--- a/src/components/SortCharacters/SortableItem.tsx
+++ b/src/components/SortCharacters/SortableItem.tsx
@@ -2,13 +2,13 @@ import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import React from "react";
 
-import { CharacterType } from "@core/types/character";
+import { Character } from "@core/types/character";
 
 import Item from "./Item";
 
 interface SortableItemProps {
   id: number;
-  character: CharacterType;
+  character: Character;
 }
 
 const SortableItem = ({ id, character, ...props }: SortableItemProps) => {

--- a/src/components/SortCharacters/index.tsx
+++ b/src/components/SortCharacters/index.tsx
@@ -24,7 +24,7 @@ import { useSetRecoilState } from "recoil";
 import * as CharacterApi from "@core/apis/character.api";
 import * as FriendApi from "@core/apis/friend.api";
 import { sortForm } from "@core/atoms/sortForm.atom";
-import { CharacterType } from "@core/types/character";
+import { Character } from "@core/types/character";
 import { FriendType } from "@core/types/friend";
 import queryKeyGenerator from "@core/utils/queryKeyGenerator";
 
@@ -34,7 +34,7 @@ import Item from "./Item";
 import SortableItem from "./SortableItem";
 
 interface Props {
-  characters: CharacterType[];
+  characters: Character[];
   friend?: FriendType;
 }
 
@@ -54,7 +54,7 @@ const calculateItemsPerRow = () => {
 };
 
 const SortCharacters: FC<Props> = ({ characters, friend }) => {
-  const beforeCharacters = useRef<CharacterType[]>();
+  const beforeCharacters = useRef<Character[]>();
 
   const queryClient = useQueryClient();
 

--- a/src/components/SortCharacters/index.tsx
+++ b/src/components/SortCharacters/index.tsx
@@ -25,7 +25,7 @@ import * as CharacterApi from "@core/apis/character.api";
 import * as FriendApi from "@core/apis/friend.api";
 import { sortForm } from "@core/atoms/sortForm.atom";
 import { Character } from "@core/types/character";
-import { FriendType } from "@core/types/friend";
+import { Friend } from "@core/types/friend";
 import queryKeyGenerator from "@core/utils/queryKeyGenerator";
 
 import BoxTitle from "@components/BoxTitle";
@@ -35,7 +35,7 @@ import SortableItem from "./SortableItem";
 
 interface Props {
   characters: Character[];
-  friend?: FriendType;
+  friend?: Friend;
 }
 
 const calculateItemsPerRow = () => {

--- a/src/components/todo/ChallangeButtons.tsx
+++ b/src/components/todo/ChallangeButtons.tsx
@@ -6,12 +6,12 @@ import { toast } from "react-toastify";
 
 import * as characterApi from "@core/apis/character.api";
 import useWindowSize from "@core/hooks/useWindowSize";
-import { CharacterType } from "@core/types/character";
+import { Character } from "@core/types/character";
 import { FriendType } from "@core/types/friend";
 import queryKeyGenerator from "@core/utils/queryKeyGenerator";
 
 interface Props {
-  characters: CharacterType[];
+  characters: Character[];
   server: string;
   friend?: FriendType;
 }

--- a/src/components/todo/ChallangeButtons.tsx
+++ b/src/components/todo/ChallangeButtons.tsx
@@ -7,13 +7,13 @@ import { toast } from "react-toastify";
 import * as characterApi from "@core/apis/character.api";
 import useWindowSize from "@core/hooks/useWindowSize";
 import { Character } from "@core/types/character";
-import { FriendType } from "@core/types/friend";
+import { Friend } from "@core/types/friend";
 import queryKeyGenerator from "@core/utils/queryKeyGenerator";
 
 interface Props {
   characters: Character[];
   server: string;
-  friend?: FriendType;
+  friend?: Friend;
 }
 
 const ChallangeButtons: FC<Props> = ({ characters, server, friend }) => {

--- a/src/components/todo/Profit.tsx
+++ b/src/components/todo/Profit.tsx
@@ -1,12 +1,12 @@
 import styled from "@emotion/styled";
 import type { FC } from "react";
 
-import { CharacterType } from "@core/types/character";
+import { Character } from "@core/types/character";
 
 import GoldIcon from "@assets/images/ico_gold.png";
 
 interface Props {
-  characters: CharacterType[];
+  characters: Character[];
 }
 
 const Profit: FC<Props> = ({ characters }) => {

--- a/src/components/todo/SelectServer.tsx
+++ b/src/components/todo/SelectServer.tsx
@@ -3,10 +3,10 @@ import { Button, Menu, MenuItem } from "@mui/material";
 import type { FC, MouseEvent } from "react";
 import { useState } from "react";
 
-import { CharacterType } from "@core/types/character";
+import { Character } from "@core/types/character";
 
 interface Props {
-  characters: CharacterType[];
+  characters: Character[];
   serverList: Map<string, number>;
   server: string;
   setServer: React.Dispatch<React.SetStateAction<string>>;

--- a/src/components/todo/TodolList/CharacterInformation.tsx
+++ b/src/components/todo/TodolList/CharacterInformation.tsx
@@ -1,9 +1,9 @@
 import styled from "@emotion/styled";
 
-import type { CharacterType } from "@core/types/character";
+import type { Character } from "@core/types/character";
 
 interface Props {
-  character: CharacterType;
+  character: Character;
 }
 
 const CharacterInformation = ({ character }: Props) => {

--- a/src/components/todo/TodolList/DailyContents.tsx
+++ b/src/components/todo/TodolList/DailyContents.tsx
@@ -11,7 +11,7 @@ import * as characterApi from "@core/apis/character.api";
 import * as friendApi from "@core/apis/friend.api";
 import { loading } from "@core/atoms/loading.atom";
 import useModalState from "@core/hooks/useModalState";
-import { CharacterType } from "@core/types/character";
+import { Character } from "@core/types/character";
 import { FriendType } from "@core/types/friend";
 import queryKeyGenerator from "@core/utils/queryKeyGenerator";
 
@@ -23,7 +23,7 @@ import RestGauge, * as RestGaugeStyledComponents from "./button/RestGauge";
 import GoldText from "./text/GoldText";
 
 interface Props {
-  character: CharacterType;
+  character: Character;
   friend?: FriendType;
 }
 
@@ -33,8 +33,7 @@ const DayilyContents: FC<Props> = ({ character, friend }) => {
   const theme = useTheme();
   const [modalState, setModalState] = useModalState<string>();
 
-  const [localCharacter, setLocalCharacter] =
-    useState<CharacterType>(character);
+  const [localCharacter, setLocalCharacter] = useState<Character>(character);
   const setLoadingState = useSetRecoilState(loading);
 
   useEffect(() => {
@@ -42,10 +41,7 @@ const DayilyContents: FC<Props> = ({ character, friend }) => {
   }, [character]);
 
   // 일일 숙제 체크/해제
-  const updateDayContent = async (
-    character: CharacterType,
-    category: string
-  ) => {
+  const updateDayContent = async (character: Character, category: string) => {
     setLoadingState(true);
     if (friend) {
       if (!friend.fromFriendSettings.checkDayTodo) {
@@ -89,7 +85,7 @@ const DayilyContents: FC<Props> = ({ character, friend }) => {
 
   // 일일 숙제 전체 체크/해제
   const updateDayContentAll = async (
-    character: CharacterType,
+    character: Character,
     category: string
   ) => {
     setLoadingState(true);
@@ -135,7 +131,7 @@ const DayilyContents: FC<Props> = ({ character, friend }) => {
 
   // 캐릭터 휴식게이지 업데이트
   const updateDayContentGauge = async (
-    updatedCharacter: CharacterType,
+    updatedCharacter: Character,
     gaugeType: string
   ) => {
     setLoadingState(true);

--- a/src/components/todo/TodolList/DailyContents.tsx
+++ b/src/components/todo/TodolList/DailyContents.tsx
@@ -12,7 +12,7 @@ import * as friendApi from "@core/apis/friend.api";
 import { loading } from "@core/atoms/loading.atom";
 import useModalState from "@core/hooks/useModalState";
 import { Character } from "@core/types/character";
-import { FriendType } from "@core/types/friend";
+import { Friend } from "@core/types/friend";
 import queryKeyGenerator from "@core/utils/queryKeyGenerator";
 
 import BoxTitle from "@components/BoxTitle";
@@ -24,7 +24,7 @@ import GoldText from "./text/GoldText";
 
 interface Props {
   character: Character;
-  friend?: FriendType;
+  friend?: Friend;
 }
 
 const DayilyContents: FC<Props> = ({ character, friend }) => {

--- a/src/components/todo/TodolList/WeeklyContents.tsx
+++ b/src/components/todo/TodolList/WeeklyContents.tsx
@@ -13,7 +13,7 @@ import * as friendApi from "@core/apis/friend.api";
 import { loading } from "@core/atoms/loading.atom";
 import useModalState from "@core/hooks/useModalState";
 import { Character } from "@core/types/character";
-import { FriendType } from "@core/types/friend";
+import { Friend } from "@core/types/friend";
 import queryKeyGenerator from "@core/utils/queryKeyGenerator";
 
 import BoxTitle from "@components/BoxTitle";
@@ -23,7 +23,7 @@ import Check, * as CheckStyledComponents from "./button/Check";
 
 interface Props {
   character: Character;
-  friend?: FriendType;
+  friend?: Friend;
 }
 
 const WeeklyContents: FC<Props> = ({ character, friend }) => {

--- a/src/components/todo/TodolList/WeeklyContents.tsx
+++ b/src/components/todo/TodolList/WeeklyContents.tsx
@@ -12,7 +12,7 @@ import * as characterApi from "@core/apis/character.api";
 import * as friendApi from "@core/apis/friend.api";
 import { loading } from "@core/atoms/loading.atom";
 import useModalState from "@core/hooks/useModalState";
-import { CharacterType } from "@core/types/character";
+import { Character } from "@core/types/character";
 import { FriendType } from "@core/types/friend";
 import queryKeyGenerator from "@core/utils/queryKeyGenerator";
 
@@ -22,7 +22,7 @@ import CubeRewardsModal from "@components/CubeRewardsModal";
 import Check, * as CheckStyledComponents from "./button/Check";
 
 interface Props {
-  character: CharacterType;
+  character: Character;
   friend?: FriendType;
 }
 

--- a/src/components/todo/TodolList/WeeklyRaids/EditModal.tsx
+++ b/src/components/todo/TodolList/WeeklyRaids/EditModal.tsx
@@ -1,0 +1,437 @@
+import styled from "@emotion/styled";
+import { Button as MuiButton } from "@mui/material";
+import { useQueryClient } from "@tanstack/react-query";
+import { toast } from "react-toastify";
+import { useSetRecoilState } from "recoil";
+
+import * as characterApi from "@core/apis/character.api";
+import { loading } from "@core/atoms/loading.atom";
+import useWeeklyRaids from "@core/hooks/queries/character/useWeeklyRaids";
+import useFriendWeeklyRaids from "@core/hooks/queries/friend/useFriendWeeklyRaids";
+import type { Character, WeeklyRaid } from "@core/types/character";
+import type { Friend } from "@core/types/friend";
+import queryKeyGenerator from "@core/utils/queryKeyGenerator";
+
+import Modal from "@components/Modal";
+
+interface Props {
+  onClose: () => void;
+  isOpen: boolean;
+  character: Character;
+  friend?: Friend;
+}
+
+const EditModal = ({ onClose, isOpen, character, friend }: Props) => {
+  const queryClient = useQueryClient();
+  const setLoadingState = useSetRecoilState(loading);
+
+  const getWeeklyRaids = useWeeklyRaids(
+    {
+      characterId: character.characterId,
+      characterName: character.characterName,
+    },
+    { enabled: isOpen && !friend }
+  );
+  const getFriendWeeklyRaids = useFriendWeeklyRaids(
+    {
+      characterId: character.characterId,
+      friendUsername: friend?.friendUsername as string,
+    },
+    { enabled: isOpen && !!friend }
+  );
+  const targetData = friend ? getFriendWeeklyRaids : getWeeklyRaids;
+
+  const invalidateData = () => {
+    if (friend) {
+      queryClient.invalidateQueries({
+        queryKey: queryKeyGenerator.getFriendWeeklyRaid({
+          characterId: character.characterId,
+          friendUsername: friend.friendUsername,
+        }),
+      });
+    } else {
+      queryClient.invalidateQueries({
+        queryKey: queryKeyGenerator.getWeeklyRaids({
+          characterId: character.characterId,
+          characterName: character.characterName,
+        }),
+      });
+    }
+  };
+
+  // 골드 획득 캐릭터 지정
+  const updateGoldCharacter = async () => {
+    setLoadingState(true);
+    if (friend) {
+      toast.warn("기능 준비 중입니다.");
+    } else {
+      try {
+        await characterApi.updateGoldCharacter(character);
+
+        queryClient.invalidateQueries({
+          queryKey: queryKeyGenerator.getCharacters(),
+        });
+        toast.success(
+          `${character.characterName}의 골드 획득 설정을 변경하였습니다.`
+        );
+        onClose();
+      } catch (error) {
+        console.error("Error updateWeekCheck:", error);
+      }
+    }
+    setLoadingState(false);
+  };
+
+  // 골드 체크 방식
+  const updateGoldCheckVersion = async () => {
+    setLoadingState(true);
+    if (friend) {
+      toast.warn("기능 준비 중입니다.");
+    } else {
+      try {
+        await characterApi.updateGoldCheckVersion(character);
+
+        queryClient.invalidateQueries({
+          queryKey: queryKeyGenerator.getCharacters(),
+        });
+        toast.success(
+          `${character.characterName}의 골드 체크 방식을 변경하였습니다.`
+        );
+        onClose();
+      } catch (error) {
+        console.error("Error updateWeekTodo All:", error);
+      }
+    }
+    setLoadingState(false);
+  };
+
+  // 컨텐츠 골드 획득 지정
+  const updateWeekGoldCheck = async (
+    weekCategory: string,
+    updateValue: boolean
+  ) => {
+    setLoadingState(true);
+    if (friend) {
+      toast.warn("기능 준비 중입니다.");
+    } else {
+      try {
+        await characterApi.updateCheckGold(
+          character,
+          weekCategory,
+          updateValue
+        );
+
+        queryClient.invalidateQueries({
+          queryKey: queryKeyGenerator.getCharacters(),
+        });
+
+        invalidateData();
+      } catch (error) {
+        console.log(error);
+      }
+    }
+    setLoadingState(false);
+  };
+
+  // 캐릭터 주간 숙제 업데이트(추가/삭제)
+  const updateWeekTodo = async (todo: WeeklyRaid) => {
+    if (friend) {
+      toast.warn("기능 준비 중입니다.");
+    } else {
+      try {
+        await characterApi.updateWeekTodo(character, todo);
+
+        queryClient.invalidateQueries({
+          queryKey: queryKeyGenerator.getCharacters(),
+        });
+
+        invalidateData();
+      } catch (error) {
+        console.error("Error updateWeekTodo:", error);
+      }
+    }
+  };
+
+  // 캐릭터 주간 숙제 업데이트 All(추가/삭제)
+  const updateWeekTodoAll = async (todos: WeeklyRaid[]) => {
+    setLoadingState(true);
+    if (friend) {
+      toast.warn("기능 준비 중입니다.");
+    } else {
+      try {
+        await characterApi.updateWeekTodoAll(character, todos);
+
+        queryClient.invalidateQueries({
+          queryKey: queryKeyGenerator.getCharacters(),
+        });
+
+        invalidateData();
+      } catch (error) {
+        console.error("Error updateWeekTodo:", error);
+      }
+    }
+    setLoadingState(false);
+  };
+
+  return (
+    <Modal
+      title={`${character.characterName} 주간 숙제 관리`}
+      isOpen={isOpen}
+      onClose={onClose}
+    >
+      {(() => {
+        const todosByCategory: {
+          [key: string]: {
+            노말: WeeklyRaid[];
+            하드: WeeklyRaid[];
+          };
+        } = {};
+        const todosGoldCheck: { [key: string]: boolean } = {};
+
+        targetData.data?.forEach((todo) => {
+          if (!todosByCategory[todo.weekCategory]) {
+            todosByCategory[todo.weekCategory] = {
+              노말: [],
+              하드: [],
+            };
+          }
+          if (todo.weekContentCategory === "노말") {
+            todosByCategory[todo.weekCategory]["노말"].push(todo);
+          } else {
+            todosByCategory[todo.weekCategory]["하드"].push(todo);
+          }
+          if (todosGoldCheck[todo.weekCategory] === undefined) {
+            todosGoldCheck[todo.weekCategory] = todo.goldCheck;
+          } else {
+            todosGoldCheck[todo.weekCategory] =
+              todosGoldCheck[todo.weekCategory] || todo.goldCheck;
+          }
+        });
+
+        const content = Object.entries(todosByCategory).map(
+          ([weekCategory, todos], index) => {
+            return (
+              <ContentWrapper key={index}>
+                <CategoryRow>
+                  <p>{weekCategory}</p>
+
+                  {character.settings.goldCheckVersion &&
+                    (todosGoldCheck[weekCategory] ? (
+                      <GetGoldButton
+                        type="button"
+                        onClick={() =>
+                          updateWeekGoldCheck(
+                            weekCategory,
+                            !todosGoldCheck[weekCategory]
+                          )
+                        }
+                      >
+                        골드 획득 지정 해제
+                      </GetGoldButton>
+                    ) : (
+                      <GetGoldButton
+                        type="button"
+                        isActive
+                        onClick={() =>
+                          updateWeekGoldCheck(
+                            weekCategory,
+                            !todosGoldCheck[weekCategory]
+                          )
+                        }
+                      >
+                        골드 획득 지정
+                      </GetGoldButton>
+                    ))}
+                </CategoryRow>
+
+                <Difficulty>
+                  {Object.entries(todos).map(
+                    ([weekContentCategory, todo], todoIndex) =>
+                      todo.length > 0 && (
+                        <GatewayButtons key={todoIndex}>
+                          <GatewayHeadButotn
+                            key={todoIndex}
+                            type="button"
+                            onClick={() => updateWeekTodoAll(todo)}
+                            isActive={
+                              todo.reduce(
+                                (count, todoItem) =>
+                                  count + (todoItem.checked ? 1 : 0),
+                                0
+                              ) === todo.length
+                            }
+                          >
+                            <p>
+                              <strong>{weekContentCategory}</strong>
+                              {todo.reduce(
+                                (sum, todoItem) => sum + todoItem.gold,
+                                0
+                              )}
+                              G
+                            </p>
+                          </GatewayHeadButotn>
+                          {todo.map((todoItem) => (
+                            <GatewayButton
+                              key={todoItem.id}
+                              type="button"
+                              isActive={todoItem.checked}
+                              onClick={() => updateWeekTodo(todoItem)}
+                            >
+                              <p>
+                                <strong>{todoItem.gate}관문</strong>
+                                {todoItem.gold}G
+                              </p>
+                            </GatewayButton>
+                          ))}
+                        </GatewayButtons>
+                      )
+                  )}
+                </Difficulty>
+              </ContentWrapper>
+            );
+          }
+        );
+
+        return (
+          <>
+            <ModalButtonsWrapper>
+              <MuiButton
+                variant="contained"
+                size="small"
+                onClick={() => updateGoldCharacter()}
+                style={{ cursor: "pointer" }}
+              >
+                골드 획득 캐릭터 지정 {character.goldCharacter ? "해제" : ""}
+              </MuiButton>
+              <MuiButton
+                variant="contained"
+                onClick={() => updateGoldCheckVersion()}
+                style={{ cursor: "pointer" }}
+              >
+                골드 획득 체크 방식 :{" "}
+                {character.settings.goldCheckVersion ? "체크 방식" : "상위 3개"}
+              </MuiButton>
+            </ModalButtonsWrapper>
+
+            {content}
+          </>
+        );
+      })()}
+    </Modal>
+  );
+};
+
+export default EditModal;
+
+const ModalButtonsWrapper = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: space-around;
+  gap: 10px;
+`;
+
+const ContentWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  margin-top: 20px;
+`;
+
+const CategoryRow = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+  line-height: 1;
+`;
+
+const GetGoldButton = styled.button<{ isActive?: boolean }>`
+  position: relative;
+  padding: 5px 10px;
+  border-radius: 4px;
+  font-size: 14px;
+  line-height: 1;
+  color: ${({ theme }) => theme.app.text.main};
+  overflow: hidden;
+
+  &:hover::before {
+    opacity: 1;
+  }
+
+  &::before {
+    z-index: -1;
+    content: "";
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: ${({ isActive, theme }) =>
+      isActive ? theme.app.gold : theme.app.blue3};
+    opacity: 0.5;
+  }
+`;
+
+const Difficulty = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+`;
+
+const GatewayButtons = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-start;
+
+  & > button {
+    flex: 1;
+    padding: 5px 0;
+    margin-left: -1px;
+  }
+`;
+
+const GatewayHeadButotn = styled.button<{ isActive?: boolean }>`
+  z-index: ${({ isActive }) => (isActive ? 1 : "unset")};
+  background: ${({ isActive, theme }) =>
+    isActive ? theme.app.blue3 : theme.app.bar.red};
+  border: 1px solid
+    ${({ isActive, theme }) =>
+      isActive ? theme.app.text.black : theme.app.border};
+  color: ${({ theme }) => theme.app.semiBlack1};
+
+  p {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 2px;
+    font-size: 12px;
+    line-height: 1.2;
+
+    strong {
+      font-size: 14px;
+      font-weight: ${({ isActive }) => (isActive ? 700 : "unset")};
+    }
+  }
+`;
+
+const GatewayButton = styled.button<{ isActive?: boolean }>`
+  z-index: ${({ isActive }) => (isActive ? 1 : "unset")};
+  border: 1px solid
+    ${({ isActive, theme }) =>
+      isActive ? theme.app.text.black : theme.app.border};
+  color: ${({ theme }) => theme.app.text.dark2};
+
+  p {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 2px;
+    font-size: 12px;
+    line-height: 1.2;
+
+    strong {
+      font-size: 14px;
+      font-weight: ${({ isActive }) => (isActive ? 700 : "unset")};
+    }
+  }
+`;

--- a/src/components/todo/TodolList/WeeklyRaids/RaidItem.tsx
+++ b/src/components/todo/TodolList/WeeklyRaids/RaidItem.tsx
@@ -65,7 +65,7 @@ const RaidItem = forwardRef<HTMLDivElement, Props>(
     };
 
     /* 주간숙제 메모 */
-    const updateWeekMessage = async (todoId: number, message: any) => {
+    const updateWeekMessage = async (todoId: number, message: string) => {
       setLoadingState(true);
 
       if (friend) {

--- a/src/components/todo/TodolList/WeeklyRaids/RaidItem.tsx
+++ b/src/components/todo/TodolList/WeeklyRaids/RaidItem.tsx
@@ -12,7 +12,7 @@ import * as characterApi from "@core/apis/character.api";
 import * as friendApi from "@core/apis/friend.api";
 import { loading } from "@core/atoms/loading.atom";
 import type { Character, Todo } from "@core/types/character";
-import type { FriendType } from "@core/types/friend";
+import type { Friend } from "@core/types/friend";
 import queryKeyGenerator from "@core/utils/queryKeyGenerator";
 
 import Check from "@components/todo/TodolList/button/Check";
@@ -24,7 +24,7 @@ import RaidNameParser from "./RaidNameParser";
 interface Props extends React.HTMLAttributes<HTMLDivElement> {
   character: Character;
   todo: Todo;
-  friend?: FriendType;
+  friend?: Friend;
   sortMode?: boolean;
   withOpacity?: boolean;
   isDragging?: boolean;

--- a/src/components/todo/TodolList/WeeklyRaids/RaidItem.tsx
+++ b/src/components/todo/TodolList/WeeklyRaids/RaidItem.tsx
@@ -11,7 +11,7 @@ import { useSetRecoilState } from "recoil";
 import * as characterApi from "@core/apis/character.api";
 import * as friendApi from "@core/apis/friend.api";
 import { loading } from "@core/atoms/loading.atom";
-import type { CharacterType, Todo } from "@core/types/character";
+import type { Character, Todo } from "@core/types/character";
 import type { FriendType } from "@core/types/friend";
 import queryKeyGenerator from "@core/utils/queryKeyGenerator";
 
@@ -22,7 +22,7 @@ import GoldText from "@components/todo/TodolList/text/GoldText";
 import RaidNameParser from "./RaidNameParser";
 
 interface Props extends React.HTMLAttributes<HTMLDivElement> {
-  character: CharacterType;
+  character: Character;
   todo: Todo;
   friend?: FriendType;
   sortMode?: boolean;

--- a/src/components/todo/TodolList/WeeklyRaids/RaidItem.tsx
+++ b/src/components/todo/TodolList/WeeklyRaids/RaidItem.tsx
@@ -11,7 +11,7 @@ import { useSetRecoilState } from "recoil";
 import * as characterApi from "@core/apis/character.api";
 import * as friendApi from "@core/apis/friend.api";
 import { loading } from "@core/atoms/loading.atom";
-import type { CharacterType, TodoType } from "@core/types/character";
+import type { CharacterType, Todo } from "@core/types/character";
 import type { FriendType } from "@core/types/friend";
 import queryKeyGenerator from "@core/utils/queryKeyGenerator";
 
@@ -23,7 +23,7 @@ import RaidNameParser from "./RaidNameParser";
 
 interface Props extends React.HTMLAttributes<HTMLDivElement> {
   character: CharacterType;
-  todo: TodoType;
+  todo: Todo;
   friend?: FriendType;
   sortMode?: boolean;
   withOpacity?: boolean;
@@ -87,7 +87,7 @@ const RaidItem = forwardRef<HTMLDivElement, Props>(
     };
 
     /* 3-1.주간숙제 체크 */
-    const updateWeekCheck = async (todo: TodoType) => {
+    const updateWeekCheck = async (todo: Todo) => {
       setLoadingState(true);
       if (friend) {
         if (!friend.fromFriendSettings.checkRaid) {
@@ -117,7 +117,7 @@ const RaidItem = forwardRef<HTMLDivElement, Props>(
     };
 
     /* 3-2. 캐릭터 주간숙제 체크 All */
-    const updateWeekCheckAll = async (todo: TodoType) => {
+    const updateWeekCheckAll = async (todo: Todo) => {
       setLoadingState(true);
 
       if (friend) {

--- a/src/components/todo/TodolList/WeeklyRaids/RaidSortWrap.tsx
+++ b/src/components/todo/TodolList/WeeklyRaids/RaidSortWrap.tsx
@@ -17,14 +17,14 @@ import {
 import { useState } from "react";
 import type { FC } from "react";
 
-import type { CharacterType, TodoType } from "@core/types/character";
+import type { CharacterType, Todo } from "@core/types/character";
 import type { FriendType } from "@core/types/friend";
 
 import RaidItem from "./RaidItem";
 import RaidSortableItem from "./RaidSortableItem";
 
 interface Props {
-  setTodos: (newTodoList: TodoType[]) => void;
+  setTodos: (newTodoList: Todo[]) => void;
   character: CharacterType;
   friend?: FriendType;
 }
@@ -83,9 +83,7 @@ const RaidSortWrap: FC<Props> = ({ setTodos, character, friend }) => {
         {activeId ? (
           <RaidItem
             id={activeId.toString()}
-            todo={
-              character.todoList.find((el) => el.id === activeId) as TodoType
-            }
+            todo={character.todoList.find((el) => el.id === activeId) as Todo}
             character={character}
             friend={friend}
             sortMode

--- a/src/components/todo/TodolList/WeeklyRaids/RaidSortWrap.tsx
+++ b/src/components/todo/TodolList/WeeklyRaids/RaidSortWrap.tsx
@@ -18,7 +18,7 @@ import { useState } from "react";
 import type { FC } from "react";
 
 import type { Character, Todo } from "@core/types/character";
-import type { FriendType } from "@core/types/friend";
+import type { Friend } from "@core/types/friend";
 
 import RaidItem from "./RaidItem";
 import RaidSortableItem from "./RaidSortableItem";
@@ -26,7 +26,7 @@ import RaidSortableItem from "./RaidSortableItem";
 interface Props {
   setTodos: (newTodoList: Todo[]) => void;
   character: Character;
-  friend?: FriendType;
+  friend?: Friend;
 }
 
 const RaidSortWrap: FC<Props> = ({ setTodos, character, friend }) => {

--- a/src/components/todo/TodolList/WeeklyRaids/RaidSortWrap.tsx
+++ b/src/components/todo/TodolList/WeeklyRaids/RaidSortWrap.tsx
@@ -17,7 +17,7 @@ import {
 import { useState } from "react";
 import type { FC } from "react";
 
-import type { CharacterType, Todo } from "@core/types/character";
+import type { Character, Todo } from "@core/types/character";
 import type { FriendType } from "@core/types/friend";
 
 import RaidItem from "./RaidItem";
@@ -25,7 +25,7 @@ import RaidSortableItem from "./RaidSortableItem";
 
 interface Props {
   setTodos: (newTodoList: Todo[]) => void;
-  character: CharacterType;
+  character: Character;
   friend?: FriendType;
 }
 

--- a/src/components/todo/TodolList/WeeklyRaids/RaidSortableItem.tsx
+++ b/src/components/todo/TodolList/WeeklyRaids/RaidSortableItem.tsx
@@ -2,7 +2,7 @@ import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { FC } from "react";
 
-import type { CharacterType, Todo } from "@core/types/character";
+import type { Character, Todo } from "@core/types/character";
 import type { FriendType } from "@core/types/friend";
 
 import RaidItem from "./RaidItem";
@@ -10,7 +10,7 @@ import RaidItem from "./RaidItem";
 interface Props {
   id: number;
   todo: Todo;
-  character: CharacterType;
+  character: Character;
   friend?: FriendType;
 }
 

--- a/src/components/todo/TodolList/WeeklyRaids/RaidSortableItem.tsx
+++ b/src/components/todo/TodolList/WeeklyRaids/RaidSortableItem.tsx
@@ -2,14 +2,14 @@ import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { FC } from "react";
 
-import type { CharacterType, TodoType } from "@core/types/character";
+import type { CharacterType, Todo } from "@core/types/character";
 import type { FriendType } from "@core/types/friend";
 
 import RaidItem from "./RaidItem";
 
 interface Props {
   id: number;
-  todo: TodoType;
+  todo: Todo;
   character: CharacterType;
   friend?: FriendType;
 }

--- a/src/components/todo/TodolList/WeeklyRaids/RaidSortableItem.tsx
+++ b/src/components/todo/TodolList/WeeklyRaids/RaidSortableItem.tsx
@@ -3,7 +3,7 @@ import { CSS } from "@dnd-kit/utilities";
 import { FC } from "react";
 
 import type { Character, Todo } from "@core/types/character";
-import type { FriendType } from "@core/types/friend";
+import type { Friend } from "@core/types/friend";
 
 import RaidItem from "./RaidItem";
 
@@ -11,7 +11,7 @@ interface Props {
   id: number;
   todo: Todo;
   character: Character;
-  friend?: FriendType;
+  friend?: Friend;
 }
 
 const RaidSortableItem: FC<Props> = ({

--- a/src/components/todo/TodolList/WeeklyRaids/index.tsx
+++ b/src/components/todo/TodolList/WeeklyRaids/index.tsx
@@ -1,5 +1,4 @@
 import styled from "@emotion/styled";
-import { Button as MuiButton } from "@mui/material";
 import { useQueryClient } from "@tanstack/react-query";
 import type { FC } from "react";
 import { useEffect, useState } from "react";
@@ -7,17 +6,16 @@ import { toast } from "react-toastify";
 import { useSetRecoilState } from "recoil";
 
 import * as characterApi from "@core/apis/character.api";
-import * as friendApi from "@core/apis/friend.api";
 import { loading } from "@core/atoms/loading.atom";
 import useModalState from "@core/hooks/useModalState";
-import { Character, WeeklyRaid } from "@core/types/character";
-import { Friend } from "@core/types/friend";
+import type { Character } from "@core/types/character";
+import type { Friend } from "@core/types/friend";
 import queryKeyGenerator from "@core/utils/queryKeyGenerator";
 
 import BoxTitle from "@components/BoxTitle";
 import Button, * as ButtonStyledComponents from "@components/Button";
-import Modal from "@components/Modal";
 
+import EditModal from "./EditModal";
 import RaidItem from "./RaidItem";
 import RaidSortWrap from "./RaidSortWrap";
 
@@ -29,7 +27,7 @@ interface Props {
 const TodoWeekRaid: FC<Props> = ({ character, friend }) => {
   const queryClient = useQueryClient();
   const setLoadingState = useSetRecoilState(loading);
-  const [modalState, setModalState] = useModalState<WeeklyRaid[]>();
+  const [modalState, setModalState] = useModalState<Friend | Character>();
 
   const [showSortRaid, setShowSortRaid] = useState(false);
   const [localCharacter, setLocalCharacter] = useState(character);
@@ -50,145 +48,6 @@ const TodoWeekRaid: FC<Props> = ({ character, friend }) => {
       setShowSortRaid(false);
     } catch (error) {
       console.error("Error saveSort:", error);
-    }
-    setLoadingState(false);
-  };
-
-  const openAddTodoForm = async () => {
-    setLoadingState(true);
-    if (friend) {
-      if (!friend.fromFriendSettings.setting) {
-        toast.warn("권한이 없습니다.");
-        setLoadingState(false);
-
-        return;
-      }
-      try {
-        const data = await friendApi.getTodoFormData(friend, character);
-        setModalState(data);
-      } catch (error) {
-        console.log(`openAddTodoFrom error : ${error}`);
-      }
-    } else {
-      try {
-        const data = await characterApi.getTodoFormData(
-          localCharacter.characterId,
-          localCharacter.characterName
-        );
-        setModalState(data);
-      } catch (error) {
-        console.log(`openAddTodoFrom error : ${error}`);
-      }
-    }
-    setLoadingState(false);
-  };
-
-  const updateGoldCheckVersion = async () => {
-    setLoadingState(true);
-    if (friend) {
-      toast.warn("기능 준비 중입니다.");
-    } else {
-      try {
-        await characterApi.updateGoldCheckVersion(localCharacter);
-
-        queryClient.invalidateQueries({
-          queryKey: queryKeyGenerator.getCharacters(),
-        });
-        toast(
-          `${localCharacter.characterName}의 골드 체크 방식을 변경하였습니다.`
-        );
-        setModalState();
-      } catch (error) {
-        console.error("Error updateWeekTodo All:", error);
-      }
-    }
-    setLoadingState(false);
-  };
-
-  // 컨텐츠 골드 획득 지정
-  const updateWeekGoldCheck = async (
-    weekCategory: string,
-    updateValue: boolean
-  ) => {
-    setLoadingState(true);
-    if (friend) {
-      toast.warn("기능 준비 중입니다.");
-    } else {
-      try {
-        await characterApi.updateCheckGold(
-          localCharacter,
-          weekCategory,
-          updateValue
-        );
-
-        queryClient.invalidateQueries({
-          queryKey: queryKeyGenerator.getCharacters(),
-        });
-        await openAddTodoForm();
-      } catch (error) {
-        console.log(error);
-      }
-    }
-    setLoadingState(false);
-  };
-
-  // 캐릭터 주간 숙제 업데이트(추가/삭제)
-  const updateWeekTodo = async (todo: WeeklyRaid) => {
-    if (friend) {
-      toast.warn("기능 준비 중입니다.");
-    } else {
-      try {
-        await characterApi.updateWeekTodo(localCharacter, todo);
-
-        queryClient.invalidateQueries({
-          queryKey: queryKeyGenerator.getCharacters(),
-        });
-        await openAddTodoForm();
-      } catch (error) {
-        console.error("Error updateWeekTodo:", error);
-      }
-    }
-  };
-
-  // 캐릭터 주간 숙제 업데이트 All(추가/삭제)
-  const updateWeekTodoAll = async (todos: WeeklyRaid[]) => {
-    setLoadingState(true);
-    if (friend) {
-      toast.warn("기능 준비 중입니다.");
-    } else {
-      try {
-        await characterApi.updateWeekTodoAll(localCharacter, todos);
-
-        queryClient.invalidateQueries({
-          queryKey: queryKeyGenerator.getCharacters(),
-        });
-        await openAddTodoForm();
-      } catch (error) {
-        console.error("Error updateWeekTodo:", error);
-      }
-    }
-    setLoadingState(false);
-  };
-
-  // 골드획득 캐릭터 업데이트
-  const updateGoldCharacter = async () => {
-    setLoadingState(true);
-    if (friend) {
-      toast.warn("기능 준비 중입니다.");
-    } else {
-      try {
-        await characterApi.updateGoldCharacter(localCharacter);
-
-        queryClient.invalidateQueries({
-          queryKey: queryKeyGenerator.getCharacters(),
-        });
-        toast(
-          `${localCharacter.characterName}의 골드 획득 설정을 변경하였습니다.`
-        );
-        setModalState();
-      } catch (error) {
-        console.error("Error updateWeekCheck:", error);
-      }
     }
     setLoadingState(false);
   };
@@ -217,7 +76,21 @@ const TodoWeekRaid: FC<Props> = ({ character, friend }) => {
                     정렬
                   </Button>
                 )}
-                <Button onClick={() => openAddTodoForm()}>편집</Button>
+                <Button
+                  onClick={() => {
+                    if (friend) {
+                      if (!friend.fromFriendSettings.setting) {
+                        toast.warn("권한이 없습니다.");
+                        return;
+                      }
+                      setModalState(friend);
+                    } else {
+                      setModalState(character);
+                    }
+                  }}
+                >
+                  편집
+                </Button>
               </ButtonsBox>
             </TitleRow>
 
@@ -254,155 +127,14 @@ const TodoWeekRaid: FC<Props> = ({ character, friend }) => {
         )}
       </Wrapper>
 
-      {modalState && (
-        <Modal
-          title={`${localCharacter.characterName} 주간 숙제 관리`}
-          isOpen={!!modalState}
-          onClose={() => setModalState()}
-        >
-          {(() => {
-            const todosByCategory: {
-              [key: string]: {
-                노말: WeeklyRaid[];
-                하드: WeeklyRaid[];
-              };
-            } = {};
-            const todosGoldCheck: { [key: string]: boolean } = {};
-
-            modalState.forEach((todo) => {
-              if (!todosByCategory[todo.weekCategory]) {
-                todosByCategory[todo.weekCategory] = {
-                  노말: [],
-                  하드: [],
-                };
-              }
-              if (todo.weekContentCategory === "노말") {
-                todosByCategory[todo.weekCategory]["노말"].push(todo);
-              } else {
-                todosByCategory[todo.weekCategory]["하드"].push(todo);
-              }
-              if (todosGoldCheck[todo.weekCategory] === undefined) {
-                todosGoldCheck[todo.weekCategory] = todo.goldCheck;
-              } else {
-                todosGoldCheck[todo.weekCategory] =
-                  todosGoldCheck[todo.weekCategory] || todo.goldCheck;
-              }
-            });
-
-            const content = Object.entries(todosByCategory).map(
-              ([weekCategory, todos], index) => {
-                return (
-                  <ContentWrapper key={index}>
-                    <CategoryRow>
-                      <p>{weekCategory}</p>
-
-                      {localCharacter.settings.goldCheckVersion &&
-                        (todosGoldCheck[weekCategory] ? (
-                          <GetGoldButton
-                            type="button"
-                            onClick={() =>
-                              updateWeekGoldCheck(
-                                weekCategory,
-                                !todosGoldCheck[weekCategory]
-                              )
-                            }
-                          >
-                            골드 획득 지정 해제
-                          </GetGoldButton>
-                        ) : (
-                          <GetGoldButton
-                            type="button"
-                            isActive
-                            onClick={() =>
-                              updateWeekGoldCheck(
-                                weekCategory,
-                                !todosGoldCheck[weekCategory]
-                              )
-                            }
-                          >
-                            골드 획득 지정
-                          </GetGoldButton>
-                        ))}
-                    </CategoryRow>
-
-                    <Difficulty>
-                      {Object.entries(todos).map(
-                        ([weekContentCategory, todo], todoIndex) =>
-                          todo.length > 0 && (
-                            <GatewayButtons key={todoIndex}>
-                              <GatewayHeadButotn
-                                key={todoIndex}
-                                type="button"
-                                onClick={() => updateWeekTodoAll(todo)}
-                                isActive={
-                                  todo.reduce(
-                                    (count, todoItem) =>
-                                      count + (todoItem.checked ? 1 : 0),
-                                    0
-                                  ) === todo.length
-                                }
-                              >
-                                <p>
-                                  <strong>{weekContentCategory}</strong>
-                                  {todo.reduce(
-                                    (sum, todoItem) => sum + todoItem.gold,
-                                    0
-                                  )}
-                                  G
-                                </p>
-                              </GatewayHeadButotn>
-                              {todo.map((todoItem) => (
-                                <GatewayButton
-                                  key={todoItem.id}
-                                  type="button"
-                                  isActive={todoItem.checked}
-                                  onClick={() => updateWeekTodo(todoItem)}
-                                >
-                                  <p>
-                                    <strong>{todoItem.gate}관문</strong>
-                                    {todoItem.gold}G
-                                  </p>
-                                </GatewayButton>
-                              ))}
-                            </GatewayButtons>
-                          )
-                      )}
-                    </Difficulty>
-                  </ContentWrapper>
-                );
-              }
-            );
-
-            return (
-              <>
-                <ModalButtonsWrapper>
-                  <MuiButton
-                    variant="contained"
-                    size="small"
-                    onClick={() => updateGoldCharacter()}
-                    style={{ cursor: "pointer" }}
-                  >
-                    골드 획득 캐릭터 지정{" "}
-                    {localCharacter.goldCharacter ? "해제" : ""}
-                  </MuiButton>
-                  <MuiButton
-                    variant="contained"
-                    onClick={() => updateGoldCheckVersion()}
-                    style={{ cursor: "pointer" }}
-                  >
-                    골드 획득 체크 방식 :{" "}
-                    {localCharacter.settings.goldCheckVersion
-                      ? "체크 방식"
-                      : "상위 3개"}
-                  </MuiButton>
-                </ModalButtonsWrapper>
-
-                {content}
-              </>
-            );
-          })()}
-        </Modal>
-      )}
+      <EditModal
+        onClose={() => {
+          setModalState();
+        }}
+        isOpen={!!modalState}
+        character={character}
+        friend={friend}
+      />
     </>
   );
 };
@@ -451,117 +183,4 @@ const ButtonsBox = styled.div`
 const SubTitle = styled.p`
   color: ${({ theme }) => theme.app.text.dark2};
   font-size: 12px;
-`;
-
-const ModalButtonsWrapper = styled.div`
-  display: flex;
-  flex-direction: row;
-  justify-content: space-around;
-  gap: 10px;
-`;
-
-const ContentWrapper = styled.div`
-  display: flex;
-  flex-direction: column;
-  gap: 3px;
-  margin-top: 20px;
-`;
-
-const CategoryRow = styled.div`
-  display: flex;
-  flex-direction: row;
-  justify-content: space-between;
-  align-items: center;
-  line-height: 1;
-`;
-
-const GetGoldButton = styled.button<{ isActive?: boolean }>`
-  position: relative;
-  padding: 5px 10px;
-  border-radius: 4px;
-  font-size: 14px;
-  line-height: 1;
-  color: ${({ theme }) => theme.app.text.main};
-  overflow: hidden;
-
-  &:hover::before {
-    opacity: 1;
-  }
-
-  &::before {
-    z-index: -1;
-    content: "";
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    background: ${({ isActive, theme }) =>
-      isActive ? theme.app.gold : theme.app.blue3};
-    opacity: 0.5;
-  }
-`;
-
-const Difficulty = styled.div`
-  display: flex;
-  flex-direction: column;
-  gap: 5px;
-`;
-
-const GatewayButtons = styled.div`
-  display: flex;
-  flex-direction: row;
-  justify-content: flex-start;
-
-  & > button {
-    flex: 1;
-    padding: 5px 0;
-    margin-left: -1px;
-  }
-`;
-
-const GatewayHeadButotn = styled.button<{ isActive?: boolean }>`
-  z-index: ${({ isActive }) => (isActive ? 1 : "unset")};
-  background: ${({ isActive, theme }) =>
-    isActive ? theme.app.blue3 : theme.app.bar.red};
-  border: 1px solid
-    ${({ isActive, theme }) =>
-      isActive ? theme.app.text.black : theme.app.border};
-  color: ${({ theme }) => theme.app.semiBlack1};
-
-  p {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: 2px;
-    font-size: 12px;
-    line-height: 1.2;
-
-    strong {
-      font-size: 14px;
-      font-weight: ${({ isActive }) => (isActive ? 700 : "unset")};
-    }
-  }
-`;
-
-const GatewayButton = styled.button<{ isActive?: boolean }>`
-  z-index: ${({ isActive }) => (isActive ? 1 : "unset")};
-  border: 1px solid
-    ${({ isActive, theme }) =>
-      isActive ? theme.app.text.black : theme.app.border};
-  color: ${({ theme }) => theme.app.text.dark2};
-
-  p {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: 2px;
-    font-size: 12px;
-    line-height: 1.2;
-
-    strong {
-      font-size: 14px;
-      font-weight: ${({ isActive }) => (isActive ? 700 : "unset")};
-    }
-  }
 `;

--- a/src/components/todo/TodolList/WeeklyRaids/index.tsx
+++ b/src/components/todo/TodolList/WeeklyRaids/index.tsx
@@ -10,7 +10,7 @@ import * as characterApi from "@core/apis/character.api";
 import * as friendApi from "@core/apis/friend.api";
 import { loading } from "@core/atoms/loading.atom";
 import useModalState from "@core/hooks/useModalState";
-import { Character, WeekContnetType } from "@core/types/character";
+import { Character, WeeklyRaid } from "@core/types/character";
 import { Friend } from "@core/types/friend";
 import queryKeyGenerator from "@core/utils/queryKeyGenerator";
 
@@ -29,7 +29,7 @@ interface Props {
 const TodoWeekRaid: FC<Props> = ({ character, friend }) => {
   const queryClient = useQueryClient();
   const setLoadingState = useSetRecoilState(loading);
-  const [modalState, setModalState] = useModalState<WeekContnetType[]>();
+  const [modalState, setModalState] = useModalState<WeeklyRaid[]>();
 
   const [showSortRaid, setShowSortRaid] = useState(false);
   const [localCharacter, setLocalCharacter] = useState(character);
@@ -133,7 +133,7 @@ const TodoWeekRaid: FC<Props> = ({ character, friend }) => {
   };
 
   // 캐릭터 주간 숙제 업데이트(추가/삭제)
-  const updateWeekTodo = async (todo: WeekContnetType) => {
+  const updateWeekTodo = async (todo: WeeklyRaid) => {
     if (friend) {
       toast.warn("기능 준비 중입니다.");
     } else {
@@ -151,7 +151,7 @@ const TodoWeekRaid: FC<Props> = ({ character, friend }) => {
   };
 
   // 캐릭터 주간 숙제 업데이트 All(추가/삭제)
-  const updateWeekTodoAll = async (todos: WeekContnetType[]) => {
+  const updateWeekTodoAll = async (todos: WeeklyRaid[]) => {
     setLoadingState(true);
     if (friend) {
       toast.warn("기능 준비 중입니다.");
@@ -263,8 +263,8 @@ const TodoWeekRaid: FC<Props> = ({ character, friend }) => {
           {(() => {
             const todosByCategory: {
               [key: string]: {
-                노말: WeekContnetType[];
-                하드: WeekContnetType[];
+                노말: WeeklyRaid[];
+                하드: WeeklyRaid[];
               };
             } = {};
             const todosGoldCheck: { [key: string]: boolean } = {};

--- a/src/components/todo/TodolList/WeeklyRaids/index.tsx
+++ b/src/components/todo/TodolList/WeeklyRaids/index.tsx
@@ -11,7 +11,7 @@ import * as friendApi from "@core/apis/friend.api";
 import { loading } from "@core/atoms/loading.atom";
 import useModalState from "@core/hooks/useModalState";
 import { Character, WeekContnetType } from "@core/types/character";
-import { FriendType } from "@core/types/friend";
+import { Friend } from "@core/types/friend";
 import queryKeyGenerator from "@core/utils/queryKeyGenerator";
 
 import BoxTitle from "@components/BoxTitle";
@@ -23,7 +23,7 @@ import RaidSortWrap from "./RaidSortWrap";
 
 interface Props {
   character: Character;
-  friend?: FriendType;
+  friend?: Friend;
 }
 
 const TodoWeekRaid: FC<Props> = ({ character, friend }) => {

--- a/src/components/todo/TodolList/WeeklyRaids/index.tsx
+++ b/src/components/todo/TodolList/WeeklyRaids/index.tsx
@@ -52,55 +52,56 @@ const TodoWeekRaid: FC<Props> = ({ character, friend }) => {
     setLoadingState(false);
   };
 
+  if (!localCharacter.settings.showWeekTodo) {
+    return null;
+  }
   return (
     <>
       <Wrapper>
-        {localCharacter.settings.showWeekTodo && (
-          <TitleBox>
-            <TitleRow>
-              <BoxTitle>주간 레이드</BoxTitle>
+        <TitleBox>
+          <TitleRow>
+            <BoxTitle>주간 레이드</BoxTitle>
 
-              <ButtonsBox>
-                {showSortRaid ? (
-                  <Button onClick={() => saveRaidSort()}>저장</Button>
-                ) : (
-                  <Button
-                    onClick={() => {
-                      if (friend) {
-                        toast.warn("기능 준비 중입니다.");
-                      } else {
-                        setShowSortRaid(true);
-                      }
-                    }}
-                  >
-                    정렬
-                  </Button>
-                )}
+            <ButtonsBox>
+              {showSortRaid ? (
+                <Button onClick={() => saveRaidSort()}>저장</Button>
+              ) : (
                 <Button
                   onClick={() => {
                     if (friend) {
-                      if (!friend.fromFriendSettings.setting) {
-                        toast.warn("권한이 없습니다.");
-                        return;
-                      }
-                      setModalState(friend);
+                      toast.warn("기능 준비 중입니다.");
                     } else {
-                      setModalState(character);
+                      setShowSortRaid(true);
                     }
                   }}
                 >
-                  편집
+                  정렬
                 </Button>
-              </ButtonsBox>
-            </TitleRow>
+              )}
+              <Button
+                onClick={() => {
+                  if (friend) {
+                    if (!friend.fromFriendSettings.setting) {
+                      toast.warn("권한이 없습니다.");
+                      return;
+                    }
+                    setModalState(friend);
+                  } else {
+                    setModalState(character);
+                  }
+                }}
+              >
+                편집
+              </Button>
+            </ButtonsBox>
+          </TitleRow>
 
-            {showSortRaid ? (
-              <SubTitle>저장 버튼 클릭시 순서가 저장됩니다</SubTitle>
-            ) : (
-              <SubTitle>마우스 우클릭 시 한번에 체크됩니다</SubTitle>
-            )}
-          </TitleBox>
-        )}
+          {showSortRaid ? (
+            <SubTitle>저장 버튼 클릭시 순서가 저장됩니다</SubTitle>
+          ) : (
+            <SubTitle>마우스 우클릭 시 한번에 체크됩니다</SubTitle>
+          )}
+        </TitleBox>
 
         {showSortRaid ? (
           <RaidSortWrap

--- a/src/components/todo/TodolList/WeeklyRaids/index.tsx
+++ b/src/components/todo/TodolList/WeeklyRaids/index.tsx
@@ -10,7 +10,7 @@ import * as characterApi from "@core/apis/character.api";
 import * as friendApi from "@core/apis/friend.api";
 import { loading } from "@core/atoms/loading.atom";
 import useModalState from "@core/hooks/useModalState";
-import { CharacterType, WeekContnetType } from "@core/types/character";
+import { Character, WeekContnetType } from "@core/types/character";
 import { FriendType } from "@core/types/friend";
 import queryKeyGenerator from "@core/utils/queryKeyGenerator";
 
@@ -22,7 +22,7 @@ import RaidItem from "./RaidItem";
 import RaidSortWrap from "./RaidSortWrap";
 
 interface Props {
-  character: CharacterType;
+  character: Character;
   friend?: FriendType;
 }
 

--- a/src/components/todo/TodolList/index.tsx
+++ b/src/components/todo/TodolList/index.tsx
@@ -3,7 +3,7 @@ import { Grid } from "@mui/material";
 import type { FC } from "react";
 
 import { Character } from "@core/types/character";
-import { FriendType } from "@core/types/friend";
+import { Friend } from "@core/types/friend";
 
 import CharacterInformation from "./CharacterInformation";
 import DailyContents from "./DailyContents";
@@ -12,7 +12,7 @@ import WeeklyRaids from "./WeeklyRaids";
 
 interface Props {
   characters: Character[];
-  friend?: FriendType;
+  friend?: Friend;
 }
 
 const TodoContent: FC<Props> = ({ characters, friend }) => {

--- a/src/components/todo/TodolList/index.tsx
+++ b/src/components/todo/TodolList/index.tsx
@@ -2,7 +2,7 @@ import styled from "@emotion/styled";
 import { Grid } from "@mui/material";
 import type { FC } from "react";
 
-import { CharacterType } from "@core/types/character";
+import { Character } from "@core/types/character";
 import { FriendType } from "@core/types/friend";
 
 import CharacterInformation from "./CharacterInformation";
@@ -11,7 +11,7 @@ import WeeklyContents from "./WeeklyContents";
 import WeeklyRaids from "./WeeklyRaids";
 
 interface Props {
-  characters: CharacterType[];
+  characters: Character[];
   friend?: FriendType;
 }
 

--- a/src/core/apis/character.api.ts
+++ b/src/core/apis/character.api.ts
@@ -29,7 +29,7 @@ export const getCubeReward = (name: CubeName): Promise<CubeReward> => {
 };
 
 // 캐릭터 정보 업데이트
-export const updateCharacters = (): Promise<any> => {
+export const refreshCharacters = (): Promise<void> => {
   return mainAxios.put("/v4/characters").then((res) => res.data);
 };
 

--- a/src/core/apis/character.api.ts
+++ b/src/core/apis/character.api.ts
@@ -2,6 +2,7 @@ import {
   Character,
   CubeName,
   CubeReward,
+  GetWeeklyRaidsRequest,
   Todo,
   WeeklyRaid,
 } from "@core/types/character";
@@ -13,10 +14,10 @@ export const getCharacters = (): Promise<Character[]> => {
 };
 
 // 캐릭터 주간 레이드 추가 폼 데이터 호출
-export const getTodoFormData = (
-  characterId: number,
-  characterName: string
-): Promise<WeeklyRaid[]> => {
+export const getWeeklyRaids = ({
+  characterId,
+  characterName,
+}: GetWeeklyRaidsRequest): Promise<WeeklyRaid[]> => {
   return mainAxios
     .get(`/v4/character/week-todo/form/${characterId}/${characterName}`)
     .then((res) => res.data);

--- a/src/core/apis/character.api.ts
+++ b/src/core/apis/character.api.ts
@@ -4,6 +4,7 @@ import {
   CubeReward,
   GetWeeklyRaidsRequest,
   Todo,
+  UpdateVisibleSettingRequest,
   WeeklyRaid,
 } from "@core/types/character";
 
@@ -34,20 +35,19 @@ export const refreshCharacters = (): Promise<void> => {
 };
 
 // 캐릭터 출력내용 업데이트
-export const updateSetting = (
-  characterId: number,
-  characterName: string,
-  value: boolean,
-  settingName: string
-): Promise<any> => {
-  const updateContent = {
-    characterId,
-    characterName,
-    value,
-    name: settingName,
-  };
+export const updateVisibleSetting = ({
+  characterId,
+  characterName,
+  value,
+  name,
+}: UpdateVisibleSettingRequest): Promise<void> => {
   return mainAxios
-    .patch("/v4/character/settings", updateContent)
+    .patch("/v4/character/settings", {
+      characterId,
+      characterName,
+      value,
+      name,
+    })
     .then((res) => res.data);
 };
 
@@ -65,70 +65,6 @@ export const updateChallenge = (
 export const saveSort = (characters: Character[]): Promise<any> => {
   return mainAxios
     .patch("/v4/characters/sorting", characters)
-    .then((res) => res.data);
-};
-
-// 일일 숙제 단일 체크
-export const updateDayContent = (
-  characterId: number,
-  characterName: string,
-  category: string
-): Promise<any> => {
-  const data = {
-    characterId,
-    characterName,
-  };
-
-  return mainAxios
-    .patch(`/v4/character/day-todo/check/${category}`, data)
-    .then((res) => res.data);
-};
-
-// 일일 숙제 전체 체크
-export const updateDayContentAll = (
-  characterId: number,
-  characterName: string,
-  category: string
-): Promise<any> => {
-  const data = {
-    characterId,
-    characterName,
-  };
-
-  return mainAxios
-    .patch(`/v4/character/day-todo/check/${category}/all`, data)
-    .then((res) => res.data);
-};
-
-// 캐릭터 휴식 게이지 수정
-export const updateDayContentGauge = (
-  characterId: number,
-  characterName: string,
-  chaosGauge: number,
-  guardianGauge: number,
-  eponaGauge: number
-): Promise<any> => {
-  const data = {
-    characterId,
-    characterName,
-    chaosGauge,
-    guardianGauge,
-    eponaGauge,
-  };
-  return mainAxios
-    .patch("/v4/character/day-todo/gauge", data)
-    .then((res) => res.data);
-};
-
-// 골드 체크 버전 변경
-export const updateGoldCheckVersion = (character: Character): Promise<any> => {
-  const data = {
-    characterId: character.characterId,
-    characterName: character.characterName,
-  };
-
-  return mainAxios
-    .patch("/v3/character/settings/gold-check-version", data)
     .then((res) => res.data);
 };
 
@@ -150,6 +86,18 @@ export const updateCheckGold = (
     .then((res) => res.data);
 };
 
+// 골드 체크 버전 변경
+export const updateGoldCheckVersion = (character: Character): Promise<any> => {
+  const data = {
+    characterId: character.characterId,
+    characterName: character.characterName,
+  };
+
+  return mainAxios
+    .patch("/v3/character/settings/gold-check-version", data)
+    .then((res) => res.data);
+};
+
 // 캐릭터 주간 레이드 업데이트(추가/삭제)
 export const updateWeekTodo = (
   character: Character,
@@ -160,37 +108,6 @@ export const updateWeekTodo = (
       `/v2/character/week/raid/${character.characterId}/${character.characterName}`,
       content
     )
-    .then((res) => res.data);
-};
-
-// 캐릭터 주간 레이드 업데이트(추가/삭제) All
-export const updateWeekTodoAll = (
-  character: Character,
-  content: WeeklyRaid[]
-): Promise<any> => {
-  return mainAxios
-    .post(
-      `/v2/character/week/raid/${character.characterId}/${character.characterName}/all`,
-      content
-    )
-    .then((res) => res.data);
-};
-
-// 캐릭터 주간 숙제 체크
-export const updateWeekCheck = (
-  character: Character,
-  todo: Todo
-): Promise<any> => {
-  const updateContent = {
-    characterId: character.characterId,
-    characterName: character.characterName,
-    weekCategory: todo.weekCategory,
-    currentGate: todo.currentGate,
-    totalGate: todo.totalGate,
-  };
-
-  return mainAxios
-    .patch("/v2/character/week/raid/check", updateContent)
     .then((res) => res.data);
 };
 
@@ -249,6 +166,91 @@ export const updateWeekMessage = (
   };
   return mainAxios
     .patch("/v2/character/week/message", updateContent)
+    .then((res) => res.data);
+};
+
+// --------------------- friend.api와 공동 작업
+
+// 일일 숙제 단일 체크
+export const updateDayContent = (
+  characterId: number,
+  characterName: string,
+  category: string
+): Promise<any> => {
+  const data = {
+    characterId,
+    characterName,
+  };
+
+  return mainAxios
+    .patch(`/v4/character/day-todo/check/${category}`, data)
+    .then((res) => res.data);
+};
+
+// 일일 숙제 전체 체크
+export const updateDayContentAll = (
+  characterId: number,
+  characterName: string,
+  category: string
+): Promise<any> => {
+  const data = {
+    characterId,
+    characterName,
+  };
+
+  return mainAxios
+    .patch(`/v4/character/day-todo/check/${category}/all`, data)
+    .then((res) => res.data);
+};
+
+// 캐릭터 휴식 게이지 수정
+export const updateDayContentGauge = (
+  characterId: number,
+  characterName: string,
+  chaosGauge: number,
+  guardianGauge: number,
+  eponaGauge: number
+): Promise<any> => {
+  const data = {
+    characterId,
+    characterName,
+    chaosGauge,
+    guardianGauge,
+    eponaGauge,
+  };
+  return mainAxios
+    .patch("/v4/character/day-todo/gauge", data)
+    .then((res) => res.data);
+};
+
+// 캐릭터 주간 숙제 체크
+export const updateWeekCheck = (
+  character: Character,
+  todo: Todo
+): Promise<any> => {
+  const updateContent = {
+    characterId: character.characterId,
+    characterName: character.characterName,
+    weekCategory: todo.weekCategory,
+    currentGate: todo.currentGate,
+    totalGate: todo.totalGate,
+  };
+
+  return mainAxios
+    .patch("/v2/character/week/raid/check", updateContent)
+    .then((res) => res.data);
+};
+
+// 캐릭터 주간 레이드 업데이트(추가/삭제) All
+export const updateWeekTodoAll = (
+  character: Character,
+  content: WeeklyRaid[]
+): Promise<any> => {
+  return mainAxios
+    .post(
+      `/v2/character/week/raid/${character.characterId}/${character.characterName}/all`,
+      content
+    )
     .then((res) => res.data);
 };
 

--- a/src/core/apis/character.api.ts
+++ b/src/core/apis/character.api.ts
@@ -2,7 +2,7 @@ import {
   CharacterType,
   CubeName,
   CubeReward,
-  TodoType,
+  Todo,
   WeekContnetType,
 } from "@core/types/character";
 
@@ -180,7 +180,7 @@ export const updateWeekTodoAll = (
 // 캐릭터 주간 숙제 체크
 export const updateWeekCheck = (
   character: CharacterType,
-  todo: TodoType
+  todo: Todo
 ): Promise<any> => {
   const updateContent = {
     characterId: character.characterId,
@@ -198,7 +198,7 @@ export const updateWeekCheck = (
 // 캐릭터 주간 숙제 체크 All
 export const updateWeekCheckAll = (
   character: CharacterType,
-  todo: TodoType
+  todo: Todo
 ): Promise<any> => {
   const updateContent = {
     characterId: character.characterId,

--- a/src/core/apis/character.api.ts
+++ b/src/core/apis/character.api.ts
@@ -3,7 +3,7 @@ import {
   CubeName,
   CubeReward,
   Todo,
-  WeekContnetType,
+  WeeklyRaid,
 } from "@core/types/character";
 
 import mainAxios from "./mainAxios";
@@ -16,7 +16,7 @@ export const getCharacters = (): Promise<Character[]> => {
 export const getTodoFormData = (
   characterId: number,
   characterName: string
-): Promise<WeekContnetType[]> => {
+): Promise<WeeklyRaid[]> => {
   return mainAxios
     .get(`/v4/character/week-todo/form/${characterId}/${characterName}`)
     .then((res) => res.data);
@@ -152,7 +152,7 @@ export const updateCheckGold = (
 // 캐릭터 주간 레이드 업데이트(추가/삭제)
 export const updateWeekTodo = (
   character: Character,
-  content: WeekContnetType
+  content: WeeklyRaid
 ): Promise<any> => {
   return mainAxios
     .post(
@@ -165,7 +165,7 @@ export const updateWeekTodo = (
 // 캐릭터 주간 레이드 업데이트(추가/삭제) All
 export const updateWeekTodoAll = (
   character: Character,
-  content: WeekContnetType[]
+  content: WeeklyRaid[]
 ): Promise<any> => {
   return mainAxios
     .post(

--- a/src/core/apis/character.api.ts
+++ b/src/core/apis/character.api.ts
@@ -1,5 +1,5 @@
 import {
-  CharacterType,
+  Character,
   CubeName,
   CubeReward,
   Todo,
@@ -8,7 +8,7 @@ import {
 
 import mainAxios from "./mainAxios";
 
-export const getCharacters = (): Promise<CharacterType[]> => {
+export const getCharacters = (): Promise<Character[]> => {
   return mainAxios.get("/v4/characters").then((res) => res.data);
 };
 
@@ -61,7 +61,7 @@ export const updateChallenge = (
 };
 
 // 캐릭터 순서 변경 저장
-export const saveSort = (characters: CharacterType[]): Promise<any> => {
+export const saveSort = (characters: Character[]): Promise<any> => {
   return mainAxios
     .patch("/v4/characters/sorting", characters)
     .then((res) => res.data);
@@ -120,9 +120,7 @@ export const updateDayContentGauge = (
 };
 
 // 골드 체크 버전 변경
-export const updateGoldCheckVersion = (
-  character: CharacterType
-): Promise<any> => {
+export const updateGoldCheckVersion = (character: Character): Promise<any> => {
   const data = {
     characterId: character.characterId,
     characterName: character.characterName,
@@ -135,7 +133,7 @@ export const updateGoldCheckVersion = (
 
 // 컨텐츠 골드 획득 지정/해제
 export const updateCheckGold = (
-  character: CharacterType,
+  character: Character,
   weekCategory: string,
   updateValue: boolean
 ): Promise<any> => {
@@ -153,7 +151,7 @@ export const updateCheckGold = (
 
 // 캐릭터 주간 레이드 업데이트(추가/삭제)
 export const updateWeekTodo = (
-  character: CharacterType,
+  character: Character,
   content: WeekContnetType
 ): Promise<any> => {
   return mainAxios
@@ -166,7 +164,7 @@ export const updateWeekTodo = (
 
 // 캐릭터 주간 레이드 업데이트(추가/삭제) All
 export const updateWeekTodoAll = (
-  character: CharacterType,
+  character: Character,
   content: WeekContnetType[]
 ): Promise<any> => {
   return mainAxios
@@ -179,7 +177,7 @@ export const updateWeekTodoAll = (
 
 // 캐릭터 주간 숙제 체크
 export const updateWeekCheck = (
-  character: CharacterType,
+  character: Character,
   todo: Todo
 ): Promise<any> => {
   const updateContent = {
@@ -197,7 +195,7 @@ export const updateWeekCheck = (
 
 // 캐릭터 주간 숙제 체크 All
 export const updateWeekCheckAll = (
-  character: CharacterType,
+  character: Character,
   todo: Todo
 ): Promise<any> => {
   const updateContent = {
@@ -212,7 +210,7 @@ export const updateWeekCheckAll = (
 };
 
 // 골드획득 캐릭터 업데이트
-export const updateGoldCharacter = (character: CharacterType): Promise<any> => {
+export const updateGoldCharacter = (character: Character): Promise<any> => {
   const updateContent = {
     characterId: character.characterId,
     characterName: character.characterName,
@@ -224,7 +222,7 @@ export const updateGoldCharacter = (character: CharacterType): Promise<any> => {
 };
 
 // 캐릭터 주간 레이드 순서 변경
-export const saveRaidSort = (character: CharacterType): Promise<any> => {
+export const saveRaidSort = (character: Character): Promise<any> => {
   const { characterId, characterName } = character;
 
   const data = character.todoList.map((todo, index) => ({
@@ -239,7 +237,7 @@ export const saveRaidSort = (character: CharacterType): Promise<any> => {
 
 // 캐릭터 주간 레이드 메시지 수정
 export const updateWeekMessage = (
-  character: CharacterType,
+  character: Character,
   todoId: number,
   message: string
 ): Promise<any> => {
@@ -254,7 +252,7 @@ export const updateWeekMessage = (
 };
 
 /* 주간 에포나 체크 */
-export const weekEponaCheck = (character: CharacterType): Promise<any> => {
+export const weekEponaCheck = (character: Character): Promise<any> => {
   const updateContent = {
     id: character.characterId,
     characterName: character.characterName,
@@ -265,7 +263,7 @@ export const weekEponaCheck = (character: CharacterType): Promise<any> => {
 };
 
 /* 주간 에포나 체크 ALL */
-export const weekEponaCheckAll = (character: CharacterType): Promise<any> => {
+export const weekEponaCheckAll = (character: Character): Promise<any> => {
   const updateContent = {
     id: character.characterId,
     characterName: character.characterName,
@@ -276,7 +274,7 @@ export const weekEponaCheckAll = (character: CharacterType): Promise<any> => {
 };
 
 /* 실마엘 교환 체크 */
-export const silmaelChange = (character: CharacterType): Promise<any> => {
+export const silmaelChange = (character: Character): Promise<any> => {
   const updateContent = {
     id: character.characterId,
     characterName: character.characterName,
@@ -287,7 +285,7 @@ export const silmaelChange = (character: CharacterType): Promise<any> => {
 };
 
 /* 큐브 티켓 추가 */
-export const addCubeTicket = (character: CharacterType): Promise<any> => {
+export const addCubeTicket = (character: Character): Promise<any> => {
   const updateContent = {
     id: character.characterId,
     characterName: character.characterName,
@@ -298,7 +296,7 @@ export const addCubeTicket = (character: CharacterType): Promise<any> => {
 };
 
 /* 큐브 티켓 감소 */
-export const substractCubeTicket = (character: CharacterType): Promise<any> => {
+export const substractCubeTicket = (character: Character): Promise<any> => {
   const updateContent = {
     id: character.characterId,
     characterName: character.characterName,

--- a/src/core/apis/friend.api.ts
+++ b/src/core/apis/friend.api.ts
@@ -1,5 +1,5 @@
 import { OkResponse } from "@core/types/api";
-import { Character, Todo, WeekContnetType } from "@core/types/character";
+import { Character, Todo, WeeklyRaid } from "@core/types/character";
 import { Friend, FriendSettings } from "@core/types/friend";
 
 import mainAxios from "./mainAxios";
@@ -29,7 +29,7 @@ export const searchCharacter = (
 export const getTodoFormData = (
   friend: Friend,
   character: Character
-): Promise<WeekContnetType[]> => {
+): Promise<WeeklyRaid[]> => {
   return mainAxios
     .get(
       `/v4/friends/week/form/${friend.friendUsername}/${character.characterId}`

--- a/src/core/apis/friend.api.ts
+++ b/src/core/apis/friend.api.ts
@@ -79,6 +79,8 @@ export const saveSort = (
     .then((res) => res.data);
 };
 
+// --------------------- character.api와 공동 작업
+
 // 일일 숙제 단일 체크
 export const updateDayContent = (
   characterId: number,

--- a/src/core/apis/friend.api.ts
+++ b/src/core/apis/friend.api.ts
@@ -1,6 +1,10 @@
 import { OkResponse } from "@core/types/api";
 import { Character, Todo, WeeklyRaid } from "@core/types/character";
-import { Friend, FriendSettings } from "@core/types/friend";
+import {
+  Friend,
+  FriendSettings,
+  SearchCharacterItem,
+} from "@core/types/friend";
 
 import mainAxios from "./mainAxios";
 
@@ -8,18 +12,10 @@ export const getFriends = (): Promise<Friend[]> => {
   return mainAxios.get("/v4/friends").then((res) => res.data);
 };
 
-export type SearchCharacterResponseType = {
-  areWeFriend: string;
-  characterListSize: number;
-  characterName: string;
-  id: number;
-  username: string;
-};
-
 // 캐릭터 검색
 export const searchCharacter = (
   searchName: string
-): Promise<SearchCharacterResponseType[]> => {
+): Promise<SearchCharacterItem[]> => {
   return mainAxios
     .get(`/v2/friends/character/${searchName}`)
     .then((res) => res.data);

--- a/src/core/apis/friend.api.ts
+++ b/src/core/apis/friend.api.ts
@@ -1,10 +1,10 @@
 import { OkResponse } from "@core/types/api";
 import { Character, Todo, WeekContnetType } from "@core/types/character";
-import { FriendSettings, FriendType } from "@core/types/friend";
+import { Friend, FriendSettings } from "@core/types/friend";
 
 import mainAxios from "./mainAxios";
 
-export const getFriends = (): Promise<FriendType[]> => {
+export const getFriends = (): Promise<Friend[]> => {
   return mainAxios.get("/v4/friends").then((res) => res.data);
 };
 
@@ -27,7 +27,7 @@ export const searchCharacter = (
 
 // 캐릭터 주간 레이드 추가 폼 데이터 호출
 export const getTodoFormData = (
-  friend: FriendType,
+  friend: Friend,
   character: Character
 ): Promise<WeekContnetType[]> => {
   return mainAxios
@@ -73,7 +73,7 @@ export const editFriendSetting = (
 
 // 캐릭터 순서 변경 저장
 export const saveSort = (
-  friend: FriendType,
+  friend: Friend,
   characters: Character[]
 ): Promise<any> => {
   return mainAxios

--- a/src/core/apis/friend.api.ts
+++ b/src/core/apis/friend.api.ts
@@ -1,9 +1,5 @@
 import { OkResponse } from "@core/types/api";
-import {
-  CharacterType,
-  TodoType,
-  WeekContnetType,
-} from "@core/types/character";
+import { CharacterType, Todo, WeekContnetType } from "@core/types/character";
 import { FriendSettings, FriendType } from "@core/types/friend";
 
 import mainAxios from "./mainAxios";
@@ -144,7 +140,7 @@ export const updateDayContentGauge = (
 // 캐릭터 주간 숙제 체크
 export const updateWeekCheck = (
   character: CharacterType,
-  todo: TodoType
+  todo: Todo
 ): Promise<any> => {
   const updateContent = {
     characterId: character.characterId,
@@ -162,7 +158,7 @@ export const updateWeekCheck = (
 // 캐릭터 주간 숙제 체크 All
 export const updateWeekCheckAll = (
   character: CharacterType,
-  todo: TodoType
+  todo: Todo
 ): Promise<any> => {
   const updateContent = {
     characterId: character.characterId,

--- a/src/core/apis/friend.api.ts
+++ b/src/core/apis/friend.api.ts
@@ -1,5 +1,5 @@
 import { OkResponse } from "@core/types/api";
-import { CharacterType, Todo, WeekContnetType } from "@core/types/character";
+import { Character, Todo, WeekContnetType } from "@core/types/character";
 import { FriendSettings, FriendType } from "@core/types/friend";
 
 import mainAxios from "./mainAxios";
@@ -28,7 +28,7 @@ export const searchCharacter = (
 // 캐릭터 주간 레이드 추가 폼 데이터 호출
 export const getTodoFormData = (
   friend: FriendType,
-  character: CharacterType
+  character: Character
 ): Promise<WeekContnetType[]> => {
   return mainAxios
     .get(
@@ -74,7 +74,7 @@ export const editFriendSetting = (
 // 캐릭터 순서 변경 저장
 export const saveSort = (
   friend: FriendType,
-  characters: CharacterType[]
+  characters: Character[]
 ): Promise<any> => {
   return mainAxios
     .patch(
@@ -139,7 +139,7 @@ export const updateDayContentGauge = (
 
 // 캐릭터 주간 숙제 체크
 export const updateWeekCheck = (
-  character: CharacterType,
+  character: Character,
   todo: Todo
 ): Promise<any> => {
   const updateContent = {
@@ -157,7 +157,7 @@ export const updateWeekCheck = (
 
 // 캐릭터 주간 숙제 체크 All
 export const updateWeekCheckAll = (
-  character: CharacterType,
+  character: Character,
   todo: Todo
 ): Promise<any> => {
   const updateContent = {
@@ -172,7 +172,7 @@ export const updateWeekCheckAll = (
 };
 
 /* 주간 에포나 체크 */
-export const weekEponaCheck = (character: CharacterType): Promise<any> => {
+export const weekEponaCheck = (character: Character): Promise<any> => {
   const updateContent = {
     id: character.characterId,
     characterName: character.characterName,
@@ -184,7 +184,7 @@ export const weekEponaCheck = (character: CharacterType): Promise<any> => {
 };
 
 /* 주간 에포나 체크 ALL */
-export const weekEponaCheckAll = (character: CharacterType): Promise<any> => {
+export const weekEponaCheckAll = (character: Character): Promise<any> => {
   const updateContent = {
     id: character.characterId,
     characterName: character.characterName,
@@ -196,7 +196,7 @@ export const weekEponaCheckAll = (character: CharacterType): Promise<any> => {
 };
 
 /* 실마엘 체크 */
-export const silmaelChange = (character: CharacterType): Promise<any> => {
+export const silmaelChange = (character: Character): Promise<any> => {
   const updateContent = {
     id: character.characterId,
     characterName: character.characterName,
@@ -208,7 +208,7 @@ export const silmaelChange = (character: CharacterType): Promise<any> => {
 };
 
 /* 큐브 티켓 추가 */
-export const addCubeTicket = (character: CharacterType): Promise<any> => {
+export const addCubeTicket = (character: Character): Promise<any> => {
   const updateContent = {
     id: character.characterId,
     characterName: character.characterName,
@@ -220,7 +220,7 @@ export const addCubeTicket = (character: CharacterType): Promise<any> => {
 };
 
 /* 큐브 티켓 감소 */
-export const substractCubeTicket = (character: CharacterType): Promise<any> => {
+export const substractCubeTicket = (character: Character): Promise<any> => {
   const updateContent = {
     id: character.characterId,
     characterName: character.characterName,

--- a/src/core/apis/friend.api.ts
+++ b/src/core/apis/friend.api.ts
@@ -3,6 +3,7 @@ import { Character, Todo, WeeklyRaid } from "@core/types/character";
 import {
   Friend,
   FriendSettings,
+  GetFriendWeeklyRaidsRequest,
   SearchCharacterItem,
 } from "@core/types/friend";
 
@@ -22,14 +23,12 @@ export const searchCharacter = (
 };
 
 // 캐릭터 주간 레이드 추가 폼 데이터 호출
-export const getTodoFormData = (
-  friend: Friend,
-  character: Character
-): Promise<WeeklyRaid[]> => {
+export const getFriendWeeklyRaids = ({
+  friendUsername,
+  characterId,
+}: GetFriendWeeklyRaidsRequest): Promise<WeeklyRaid[]> => {
   return mainAxios
-    .get(
-      `/v4/friends/week/form/${friend.friendUsername}/${character.characterId}`
-    )
+    .get(`/v4/friends/week/form/${friendUsername}/${characterId}`)
     .then((res) => res.data);
 };
 

--- a/src/core/apis/member.api.ts
+++ b/src/core/apis/member.api.ts
@@ -21,10 +21,9 @@ export const updateMainCharacter = ({
 
 export const updateApikey = ({
   apiKey,
-  characterName,
 }: UpdateApiKeyRequest): Promise<OkResponse> => {
   return mainAxios
-    .patch("/v4/member/api-key", { apiKey, characterName })
+    .patch("/v4/member/api-key", { apiKey })
     .then((res) => res.data);
 };
 

--- a/src/core/hooks/mutations/auth/useAuthEmail.ts
+++ b/src/core/hooks/mutations/auth/useAuthEmail.ts
@@ -2,11 +2,11 @@ import { useMutation } from "@tanstack/react-query";
 
 import * as authApi from "@core/apis/auth.api";
 import type { OkResponse } from "@core/types/api";
-import type { UseMutationWithParams } from "@core/types/app";
+import type { CommonUseMutationOptions } from "@core/types/app";
 import type { AuthEmailRequest } from "@core/types/auth";
 
 export default (
-  options?: UseMutationWithParams<AuthEmailRequest, OkResponse>
+  options?: CommonUseMutationOptions<AuthEmailRequest, OkResponse>
 ) => {
   const mutation = useMutation({
     ...options,

--- a/src/core/hooks/mutations/auth/useAuthEmail.ts
+++ b/src/core/hooks/mutations/auth/useAuthEmail.ts
@@ -5,7 +5,7 @@ import type { OkResponse } from "@core/types/api";
 import type { UseMutationWithParams } from "@core/types/app";
 import type { AuthEmailRequest } from "@core/types/auth";
 
-const useAuthEmail = (
+export default (
   options?: UseMutationWithParams<AuthEmailRequest, OkResponse>
 ) => {
   const mutation = useMutation({
@@ -15,5 +15,3 @@ const useAuthEmail = (
 
   return mutation;
 };
-
-export default useAuthEmail;

--- a/src/core/hooks/mutations/auth/useIdPwLogin.ts
+++ b/src/core/hooks/mutations/auth/useIdPwLogin.ts
@@ -1,11 +1,11 @@
 import { useMutation } from "@tanstack/react-query";
 
 import * as authApi from "@core/apis/auth.api";
-import type { UseMutationWithParams } from "@core/types/app";
+import type { CommonUseMutationOptions } from "@core/types/app";
 import type { IdPwLoginRequest, IdPwLoginResponse } from "@core/types/auth";
 
 export default (
-  options?: UseMutationWithParams<IdPwLoginRequest, IdPwLoginResponse>
+  options?: CommonUseMutationOptions<IdPwLoginRequest, IdPwLoginResponse>
 ) => {
   const mutation = useMutation({
     ...options,

--- a/src/core/hooks/mutations/auth/useIdPwLogin.ts
+++ b/src/core/hooks/mutations/auth/useIdPwLogin.ts
@@ -4,7 +4,7 @@ import * as authApi from "@core/apis/auth.api";
 import type { UseMutationWithParams } from "@core/types/app";
 import type { IdPwLoginRequest, IdPwLoginResponse } from "@core/types/auth";
 
-const useIdPwLogin = (
+export default (
   options?: UseMutationWithParams<IdPwLoginRequest, IdPwLoginResponse>
 ) => {
   const mutation = useMutation({
@@ -14,5 +14,3 @@ const useIdPwLogin = (
 
   return mutation;
 };
-
-export default useIdPwLogin;

--- a/src/core/hooks/mutations/auth/useLogout.ts
+++ b/src/core/hooks/mutations/auth/useLogout.ts
@@ -4,7 +4,7 @@ import * as authApi from "@core/apis/auth.api";
 import type { OkResponse } from "@core/types/api";
 import type { UseMutationWithParams } from "@core/types/app";
 
-const useLogout = (options?: UseMutationWithParams<void, OkResponse>) => {
+export default (options?: UseMutationWithParams<void, OkResponse>) => {
   const mutation = useMutation({
     ...options,
     mutationFn: () => authApi.logout(),
@@ -12,5 +12,3 @@ const useLogout = (options?: UseMutationWithParams<void, OkResponse>) => {
 
   return mutation;
 };
-
-export default useLogout;

--- a/src/core/hooks/mutations/auth/useLogout.ts
+++ b/src/core/hooks/mutations/auth/useLogout.ts
@@ -2,9 +2,9 @@ import { useMutation } from "@tanstack/react-query";
 
 import * as authApi from "@core/apis/auth.api";
 import type { OkResponse } from "@core/types/api";
-import type { UseMutationWithParams } from "@core/types/app";
+import type { CommonUseMutationOptions } from "@core/types/app";
 
-export default (options?: UseMutationWithParams<void, OkResponse>) => {
+export default (options?: CommonUseMutationOptions<void, OkResponse>) => {
   const mutation = useMutation({
     ...options,
     mutationFn: () => authApi.logout(),

--- a/src/core/hooks/mutations/auth/useRegisterCharacters.ts
+++ b/src/core/hooks/mutations/auth/useRegisterCharacters.ts
@@ -2,11 +2,11 @@ import { useMutation } from "@tanstack/react-query";
 
 import * as authApi from "@core/apis/auth.api";
 import type { OkResponse } from "@core/types/api";
-import type { UseMutationWithParams } from "@core/types/app";
+import type { CommonUseMutationOptions } from "@core/types/app";
 import type { RegisterCharactersRequest } from "@core/types/auth";
 
 export default (
-  options?: UseMutationWithParams<RegisterCharactersRequest, OkResponse>
+  options?: CommonUseMutationOptions<RegisterCharactersRequest, OkResponse>
 ) => {
   const mutation = useMutation({
     ...options,

--- a/src/core/hooks/mutations/auth/useRegisterCharacters.ts
+++ b/src/core/hooks/mutations/auth/useRegisterCharacters.ts
@@ -5,7 +5,7 @@ import type { OkResponse } from "@core/types/api";
 import type { UseMutationWithParams } from "@core/types/app";
 import type { RegisterCharactersRequest } from "@core/types/auth";
 
-const useRegisterCharacters = (
+export default (
   options?: UseMutationWithParams<RegisterCharactersRequest, OkResponse>
 ) => {
   const mutation = useMutation({
@@ -15,5 +15,3 @@ const useRegisterCharacters = (
 
   return mutation;
 };
-
-export default useRegisterCharacters;

--- a/src/core/hooks/mutations/auth/useRequestCertificationEmail.ts
+++ b/src/core/hooks/mutations/auth/useRequestCertificationEmail.ts
@@ -5,7 +5,7 @@ import type { OkResponse } from "@core/types/api";
 import type { UseMutationWithParams } from "@core/types/app";
 import type { RequestCertificationEmailRequest } from "@core/types/auth";
 
-const useRequestCertificationEmail = (
+export default (
   options?: UseMutationWithParams<RequestCertificationEmailRequest, OkResponse>
 ) => {
   const mutation = useMutation({
@@ -15,5 +15,3 @@ const useRequestCertificationEmail = (
 
   return mutation;
 };
-
-export default useRequestCertificationEmail;

--- a/src/core/hooks/mutations/auth/useRequestCertificationEmail.ts
+++ b/src/core/hooks/mutations/auth/useRequestCertificationEmail.ts
@@ -2,11 +2,14 @@ import { useMutation } from "@tanstack/react-query";
 
 import * as authApi from "@core/apis/auth.api";
 import type { OkResponse } from "@core/types/api";
-import type { UseMutationWithParams } from "@core/types/app";
+import type { CommonUseMutationOptions } from "@core/types/app";
 import type { RequestCertificationEmailRequest } from "@core/types/auth";
 
 export default (
-  options?: UseMutationWithParams<RequestCertificationEmailRequest, OkResponse>
+  options?: CommonUseMutationOptions<
+    RequestCertificationEmailRequest,
+    OkResponse
+  >
 ) => {
   const mutation = useMutation({
     ...options,

--- a/src/core/hooks/mutations/auth/useSignup.ts
+++ b/src/core/hooks/mutations/auth/useSignup.ts
@@ -1,11 +1,11 @@
 import { useMutation } from "@tanstack/react-query";
 
 import * as authApi from "@core/apis/auth.api";
-import type { UseMutationWithParams } from "@core/types/app";
+import type { CommonUseMutationOptions } from "@core/types/app";
 import type { SignupRequest, SignupResponse } from "@core/types/auth";
 
 export default (
-  options?: UseMutationWithParams<SignupRequest, SignupResponse>
+  options?: CommonUseMutationOptions<SignupRequest, SignupResponse>
 ) => {
   const mutation = useMutation({
     ...options,

--- a/src/core/hooks/mutations/auth/useSignup.ts
+++ b/src/core/hooks/mutations/auth/useSignup.ts
@@ -4,7 +4,7 @@ import * as authApi from "@core/apis/auth.api";
 import type { UseMutationWithParams } from "@core/types/app";
 import type { SignupRequest, SignupResponse } from "@core/types/auth";
 
-const useSignup = (
+export default (
   options?: UseMutationWithParams<SignupRequest, SignupResponse>
 ) => {
   const mutation = useMutation({
@@ -14,5 +14,3 @@ const useSignup = (
 
   return mutation;
 };
-
-export default useSignup;

--- a/src/core/hooks/mutations/character/useRefreshCharacters.ts
+++ b/src/core/hooks/mutations/character/useRefreshCharacters.ts
@@ -1,0 +1,13 @@
+import { useMutation } from "@tanstack/react-query";
+
+import * as characterApi from "@core/apis/character.api";
+import type { CommonUseMutationOptions } from "@core/types/app";
+
+export default (options?: CommonUseMutationOptions) => {
+  const mutation = useMutation({
+    ...options,
+    mutationFn: () => characterApi.refreshCharacters(),
+  });
+
+  return mutation;
+};

--- a/src/core/hooks/mutations/character/useUpdateVisibleSetting.ts
+++ b/src/core/hooks/mutations/character/useUpdateVisibleSetting.ts
@@ -1,0 +1,16 @@
+import { useMutation } from "@tanstack/react-query";
+
+import * as characterApi from "@core/apis/character.api";
+import type { CommonUseMutationOptions } from "@core/types/app";
+import type { UpdateVisibleSettingRequest } from "@core/types/character";
+
+export default (
+  options?: CommonUseMutationOptions<UpdateVisibleSettingRequest>
+) => {
+  const mutation = useMutation({
+    ...options,
+    mutationFn: (params) => characterApi.updateVisibleSetting(params),
+  });
+
+  return mutation;
+};

--- a/src/core/hooks/mutations/comment/useAddComment.ts
+++ b/src/core/hooks/mutations/comment/useAddComment.ts
@@ -2,11 +2,11 @@ import { useMutation } from "@tanstack/react-query";
 
 import * as commentApi from "@core/apis/comment.api";
 import type { OkResponse } from "@core/types/api";
-import type { UseMutationWithParams } from "@core/types/app";
+import type { CommonUseMutationOptions } from "@core/types/app";
 import type { AddCommentRequest } from "@core/types/comment";
 
 export default (
-  options?: UseMutationWithParams<AddCommentRequest, OkResponse>
+  options?: CommonUseMutationOptions<AddCommentRequest, OkResponse>
 ) => {
   const mutation = useMutation({
     ...options,

--- a/src/core/hooks/mutations/comment/useAddComment.ts
+++ b/src/core/hooks/mutations/comment/useAddComment.ts
@@ -5,7 +5,7 @@ import type { OkResponse } from "@core/types/api";
 import type { UseMutationWithParams } from "@core/types/app";
 import type { AddCommentRequest } from "@core/types/comment";
 
-const useAddComment = (
+export default (
   options?: UseMutationWithParams<AddCommentRequest, OkResponse>
 ) => {
   const mutation = useMutation({
@@ -15,5 +15,3 @@ const useAddComment = (
 
   return mutation;
 };
-
-export default useAddComment;

--- a/src/core/hooks/mutations/comment/useEditComment.ts
+++ b/src/core/hooks/mutations/comment/useEditComment.ts
@@ -2,11 +2,11 @@ import { useMutation } from "@tanstack/react-query";
 
 import * as commentApi from "@core/apis/comment.api";
 import type { OkResponse } from "@core/types/api";
-import type { UseMutationWithParams } from "@core/types/app";
+import type { CommonUseMutationOptions } from "@core/types/app";
 import type { EditCommentRequest } from "@core/types/comment";
 
 export default (
-  options?: UseMutationWithParams<EditCommentRequest, OkResponse>
+  options?: CommonUseMutationOptions<EditCommentRequest, OkResponse>
 ) => {
   const mutation = useMutation({
     ...options,

--- a/src/core/hooks/mutations/comment/useEditComment.ts
+++ b/src/core/hooks/mutations/comment/useEditComment.ts
@@ -5,7 +5,7 @@ import type { OkResponse } from "@core/types/api";
 import type { UseMutationWithParams } from "@core/types/app";
 import type { EditCommentRequest } from "@core/types/comment";
 
-const useEditComment = (
+export default (
   options?: UseMutationWithParams<EditCommentRequest, OkResponse>
 ) => {
   const mutation = useMutation({
@@ -15,5 +15,3 @@ const useEditComment = (
 
   return mutation;
 };
-
-export default useEditComment;

--- a/src/core/hooks/mutations/comment/useRemoveComment.ts
+++ b/src/core/hooks/mutations/comment/useRemoveComment.ts
@@ -2,9 +2,9 @@ import { useMutation } from "@tanstack/react-query";
 
 import * as commentApi from "@core/apis/comment.api";
 import type { OkResponse } from "@core/types/api";
-import type { UseMutationWithParams } from "@core/types/app";
+import type { CommonUseMutationOptions } from "@core/types/app";
 
-export default (options?: UseMutationWithParams<number, OkResponse>) => {
+export default (options?: CommonUseMutationOptions<number, OkResponse>) => {
   const mutation = useMutation({
     ...options,
     mutationFn: (commentId) => commentApi.removeComment(commentId),

--- a/src/core/hooks/mutations/comment/useRemoveComment.ts
+++ b/src/core/hooks/mutations/comment/useRemoveComment.ts
@@ -4,9 +4,7 @@ import * as commentApi from "@core/apis/comment.api";
 import type { OkResponse } from "@core/types/api";
 import type { UseMutationWithParams } from "@core/types/app";
 
-const useRemoveComment = (
-  options?: UseMutationWithParams<number, OkResponse>
-) => {
+export default (options?: UseMutationWithParams<number, OkResponse>) => {
   const mutation = useMutation({
     ...options,
     mutationFn: (commentId) => commentApi.removeComment(commentId),
@@ -14,5 +12,3 @@ const useRemoveComment = (
 
   return mutation;
 };
-
-export default useRemoveComment;

--- a/src/core/hooks/mutations/friend/useRemoveFriend.ts
+++ b/src/core/hooks/mutations/friend/useRemoveFriend.ts
@@ -4,9 +4,7 @@ import * as friendsApi from "@core/apis/friend.api";
 import type { OkResponse } from "@core/types/api";
 import type { UseMutationWithParams } from "@core/types/app";
 
-const useRemoveFriend = (
-  options?: UseMutationWithParams<number, OkResponse>
-) => {
+export default (options?: UseMutationWithParams<number, OkResponse>) => {
   const mutation = useMutation({
     ...options,
     mutationFn: (friendId) => friendsApi.removeFriend(friendId),
@@ -14,5 +12,3 @@ const useRemoveFriend = (
 
   return mutation;
 };
-
-export default useRemoveFriend;

--- a/src/core/hooks/mutations/friend/useRemoveFriend.ts
+++ b/src/core/hooks/mutations/friend/useRemoveFriend.ts
@@ -2,9 +2,9 @@ import { useMutation } from "@tanstack/react-query";
 
 import * as friendsApi from "@core/apis/friend.api";
 import type { OkResponse } from "@core/types/api";
-import type { UseMutationWithParams } from "@core/types/app";
+import type { CommonUseMutationOptions } from "@core/types/app";
 
-export default (options?: UseMutationWithParams<number, OkResponse>) => {
+export default (options?: CommonUseMutationOptions<number, OkResponse>) => {
   const mutation = useMutation({
     ...options,
     mutationFn: (friendId) => friendsApi.removeFriend(friendId),

--- a/src/core/hooks/mutations/image/useUploadImage.ts
+++ b/src/core/hooks/mutations/image/useUploadImage.ts
@@ -1,10 +1,12 @@
 import { useMutation } from "@tanstack/react-query";
 
 import * as imageApi from "@core/apis/image.api";
-import type { UseMutationWithParams } from "@core/types/app";
+import type { CommonUseMutationOptions } from "@core/types/app";
 import type { UploadImageResponse } from "@core/types/image";
 
-export default (options?: UseMutationWithParams<Blob, UploadImageResponse>) => {
+export default (
+  options?: CommonUseMutationOptions<Blob, UploadImageResponse>
+) => {
   const mutation = useMutation({
     ...options,
     mutationFn: (blob) => imageApi.uploadImage(blob),

--- a/src/core/hooks/mutations/image/useUploadImage.ts
+++ b/src/core/hooks/mutations/image/useUploadImage.ts
@@ -4,9 +4,7 @@ import * as imageApi from "@core/apis/image.api";
 import type { UseMutationWithParams } from "@core/types/app";
 import type { UploadImageResponse } from "@core/types/image";
 
-const useUploadImage = (
-  options?: UseMutationWithParams<Blob, UploadImageResponse>
-) => {
+export default (options?: UseMutationWithParams<Blob, UploadImageResponse>) => {
   const mutation = useMutation({
     ...options,
     mutationFn: (blob) => imageApi.uploadImage(blob),
@@ -14,5 +12,3 @@ const useUploadImage = (
 
   return mutation;
 };
-
-export default useUploadImage;

--- a/src/core/hooks/mutations/member/useResetCharacters.ts
+++ b/src/core/hooks/mutations/member/useResetCharacters.ts
@@ -2,9 +2,9 @@ import { useMutation } from "@tanstack/react-query";
 
 import * as memberApi from "@core/apis/member.api";
 import type { OkResponse } from "@core/types/api";
-import type { UseMutationWithParams } from "@core/types/app";
+import type { CommonUseMutationOptions } from "@core/types/app";
 
-export default (options?: UseMutationWithParams<void, OkResponse>) => {
+export default (options?: CommonUseMutationOptions<void, OkResponse>) => {
   const mutation = useMutation({
     ...options,
     mutationFn: () => memberApi.resetCharacters(),

--- a/src/core/hooks/mutations/member/useResetCharacters.ts
+++ b/src/core/hooks/mutations/member/useResetCharacters.ts
@@ -4,9 +4,7 @@ import * as memberApi from "@core/apis/member.api";
 import type { OkResponse } from "@core/types/api";
 import type { UseMutationWithParams } from "@core/types/app";
 
-const useResetCharacters = (
-  options?: UseMutationWithParams<void, OkResponse>
-) => {
+export default (options?: UseMutationWithParams<void, OkResponse>) => {
   const mutation = useMutation({
     ...options,
     mutationFn: () => memberApi.resetCharacters(),
@@ -14,5 +12,3 @@ const useResetCharacters = (
 
   return mutation;
 };
-
-export default useResetCharacters;

--- a/src/core/hooks/mutations/member/useUpdateApiKey.ts
+++ b/src/core/hooks/mutations/member/useUpdateApiKey.ts
@@ -2,11 +2,11 @@ import { useMutation } from "@tanstack/react-query";
 
 import * as memberApi from "@core/apis/member.api";
 import type { OkResponse } from "@core/types/api";
-import type { UseMutationWithParams } from "@core/types/app";
+import type { CommonUseMutationOptions } from "@core/types/app";
 import type { UpdateApiKeyRequest } from "@core/types/member";
 
 export default (
-  options?: UseMutationWithParams<UpdateApiKeyRequest, OkResponse>
+  options?: CommonUseMutationOptions<UpdateApiKeyRequest, OkResponse>
 ) => {
   const mutation = useMutation({
     ...options,

--- a/src/core/hooks/mutations/member/useUpdateApiKey.ts
+++ b/src/core/hooks/mutations/member/useUpdateApiKey.ts
@@ -5,7 +5,7 @@ import type { OkResponse } from "@core/types/api";
 import type { UseMutationWithParams } from "@core/types/app";
 import type { UpdateApiKeyRequest } from "@core/types/member";
 
-const useUpdateApiKey = (
+export default (
   options?: UseMutationWithParams<UpdateApiKeyRequest, OkResponse>
 ) => {
   const mutation = useMutation({
@@ -15,5 +15,3 @@ const useUpdateApiKey = (
 
   return mutation;
 };
-
-export default useUpdateApiKey;

--- a/src/core/hooks/mutations/member/useUpdateMainCharacter.ts
+++ b/src/core/hooks/mutations/member/useUpdateMainCharacter.ts
@@ -5,7 +5,7 @@ import type { OkResponse } from "@core/types/api";
 import type { UseMutationWithParams } from "@core/types/app";
 import type { UpdateMainCharacterRequest } from "@core/types/member";
 
-const useUpdateMainCharacter = (
+export default (
   options?: UseMutationWithParams<UpdateMainCharacterRequest, OkResponse>
 ) => {
   const mutation = useMutation({
@@ -15,5 +15,3 @@ const useUpdateMainCharacter = (
 
   return mutation;
 };
-
-export default useUpdateMainCharacter;

--- a/src/core/hooks/mutations/member/useUpdateMainCharacter.ts
+++ b/src/core/hooks/mutations/member/useUpdateMainCharacter.ts
@@ -2,11 +2,11 @@ import { useMutation } from "@tanstack/react-query";
 
 import * as memberApi from "@core/apis/member.api";
 import type { OkResponse } from "@core/types/api";
-import type { UseMutationWithParams } from "@core/types/app";
+import type { CommonUseMutationOptions } from "@core/types/app";
 import type { UpdateMainCharacterRequest } from "@core/types/member";
 
 export default (
-  options?: UseMutationWithParams<UpdateMainCharacterRequest, OkResponse>
+  options?: CommonUseMutationOptions<UpdateMainCharacterRequest, OkResponse>
 ) => {
   const mutation = useMutation({
     ...options,

--- a/src/core/hooks/mutations/notice/useAddNotice.ts
+++ b/src/core/hooks/mutations/notice/useAddNotice.ts
@@ -4,7 +4,7 @@ import * as noticeApi from "@core/apis/notice.api";
 import type { UseMutationWithParams } from "@core/types/app";
 import type { AddNoticeRequest, NoticeItem } from "@core/types/notice";
 
-const useAddNotice = (
+export default (
   options?: UseMutationWithParams<AddNoticeRequest, NoticeItem>
 ) => {
   const mutation = useMutation({
@@ -14,5 +14,3 @@ const useAddNotice = (
 
   return mutation;
 };
-
-export default useAddNotice;

--- a/src/core/hooks/mutations/notice/useAddNotice.ts
+++ b/src/core/hooks/mutations/notice/useAddNotice.ts
@@ -1,11 +1,11 @@
 import { useMutation } from "@tanstack/react-query";
 
 import * as noticeApi from "@core/apis/notice.api";
-import type { UseMutationWithParams } from "@core/types/app";
+import type { CommonUseMutationOptions } from "@core/types/app";
 import type { AddNoticeRequest, NoticeItem } from "@core/types/notice";
 
 export default (
-  options?: UseMutationWithParams<AddNoticeRequest, NoticeItem>
+  options?: CommonUseMutationOptions<AddNoticeRequest, NoticeItem>
 ) => {
   const mutation = useMutation({
     ...options,

--- a/src/core/hooks/queries/character/useCharacters.ts
+++ b/src/core/hooks/queries/character/useCharacters.ts
@@ -6,7 +6,7 @@ import type { CommonUseQueryOptions } from "@core/types/app";
 import type { CharacterType } from "@core/types/character";
 import queryKeyGenerator from "@core/utils/queryKeyGenerator";
 
-const useCharacters = (options?: CommonUseQueryOptions<CharacterType[]>) => {
+export default (options?: CommonUseQueryOptions<CharacterType[]>) => {
   const query = useQuery({
     ...options,
     queryKey: queryKeyGenerator.getCharacters(),
@@ -16,5 +16,3 @@ const useCharacters = (options?: CommonUseQueryOptions<CharacterType[]>) => {
 
   return query;
 };
-
-export default useCharacters;

--- a/src/core/hooks/queries/character/useCharacters.ts
+++ b/src/core/hooks/queries/character/useCharacters.ts
@@ -3,10 +3,10 @@ import { useQuery } from "@tanstack/react-query";
 import * as characterApi from "@core/apis/character.api";
 import { STALE_TIME_MS } from "@core/constants";
 import type { CommonUseQueryOptions } from "@core/types/app";
-import type { CharacterType } from "@core/types/character";
+import type { Character } from "@core/types/character";
 import queryKeyGenerator from "@core/utils/queryKeyGenerator";
 
-export default (options?: CommonUseQueryOptions<CharacterType[]>) => {
+export default (options?: CommonUseQueryOptions<Character[]>) => {
   const query = useQuery({
     ...options,
     queryKey: queryKeyGenerator.getCharacters(),

--- a/src/core/hooks/queries/character/useCubeReward.ts
+++ b/src/core/hooks/queries/character/useCubeReward.ts
@@ -5,7 +5,7 @@ import type { CommonUseQueryOptions } from "@core/types/app";
 import type { CubeName, CubeReward } from "@core/types/character";
 import queryKeyGenerator from "@core/utils/queryKeyGenerator";
 
-const useCubeReward = (
+export default (
   name: CubeName,
   options?: CommonUseQueryOptions<CubeReward>
 ) => {
@@ -17,5 +17,3 @@ const useCubeReward = (
 
   return query;
 };
-
-export default useCubeReward;

--- a/src/core/hooks/queries/character/useWeeklyRaids.ts
+++ b/src/core/hooks/queries/character/useWeeklyRaids.ts
@@ -1,0 +1,19 @@
+import { useQuery } from "@tanstack/react-query";
+
+import * as characterApi from "@core/apis/character.api";
+import type { CommonUseQueryOptions } from "@core/types/app";
+import type { GetWeeklyRaidsRequest, WeeklyRaid } from "@core/types/character";
+import queryKeyGenerator from "@core/utils/queryKeyGenerator";
+
+export default (
+  params: GetWeeklyRaidsRequest,
+  options?: CommonUseQueryOptions<WeeklyRaid[]>
+) => {
+  const query = useQuery({
+    ...options,
+    queryKey: queryKeyGenerator.getWeeklyRaids(params),
+    queryFn: () => characterApi.getWeeklyRaids(params),
+  });
+
+  return query;
+};

--- a/src/core/hooks/queries/comment/useComments.ts
+++ b/src/core/hooks/queries/comment/useComments.ts
@@ -8,7 +8,7 @@ import type {
 } from "@core/types/comment";
 import queryKeyGenerator from "@core/utils/queryKeyGenerator";
 
-const useComments = (
+export default (
   params: GetCommentsRequest,
   options?: CommonUseQueryOptions<GetCommentsResponse>
 ) => {
@@ -20,5 +20,3 @@ const useComments = (
 
   return query;
 };
-
-export default useComments;

--- a/src/core/hooks/queries/friend/useFriendWeeklyRaids.ts
+++ b/src/core/hooks/queries/friend/useFriendWeeklyRaids.ts
@@ -1,0 +1,20 @@
+import { useQuery } from "@tanstack/react-query";
+
+import * as friendApi from "@core/apis/friend.api";
+import type { CommonUseQueryOptions } from "@core/types/app";
+import type { WeeklyRaid } from "@core/types/character";
+import type { GetFriendWeeklyRaidsRequest } from "@core/types/friend";
+import queryKeyGenerator from "@core/utils/queryKeyGenerator";
+
+export default (
+  params: GetFriendWeeklyRaidsRequest,
+  options?: CommonUseQueryOptions<WeeklyRaid[]>
+) => {
+  const query = useQuery({
+    ...options,
+    queryKey: queryKeyGenerator.getFriendWeeklyRaid(params),
+    queryFn: () => friendApi.getFriendWeeklyRaids(params),
+  });
+
+  return query;
+};

--- a/src/core/hooks/queries/friend/useFriends.ts
+++ b/src/core/hooks/queries/friend/useFriends.ts
@@ -6,7 +6,7 @@ import type { CommonUseQueryOptions } from "@core/types/app";
 import type { FriendType } from "@core/types/friend";
 import queryKeyGenerator from "@core/utils/queryKeyGenerator";
 
-const useFriends = (options?: CommonUseQueryOptions<FriendType[]>) => {
+export default (options?: CommonUseQueryOptions<FriendType[]>) => {
   const query = useQuery({
     ...options,
     queryKey: queryKeyGenerator.getFriends(),
@@ -16,5 +16,3 @@ const useFriends = (options?: CommonUseQueryOptions<FriendType[]>) => {
 
   return query;
 };
-
-export default useFriends;

--- a/src/core/hooks/queries/friend/useFriends.ts
+++ b/src/core/hooks/queries/friend/useFriends.ts
@@ -3,10 +3,10 @@ import { useQuery } from "@tanstack/react-query";
 import * as friendsApi from "@core/apis/friend.api";
 import { STALE_TIME_MS } from "@core/constants";
 import type { CommonUseQueryOptions } from "@core/types/app";
-import type { FriendType } from "@core/types/friend";
+import type { Friend } from "@core/types/friend";
 import queryKeyGenerator from "@core/utils/queryKeyGenerator";
 
-export default (options?: CommonUseQueryOptions<FriendType[]>) => {
+export default (options?: CommonUseQueryOptions<Friend[]>) => {
   const query = useQuery({
     ...options,
     queryKey: queryKeyGenerator.getFriends(),

--- a/src/core/hooks/queries/friend/useSearchCharacter.ts
+++ b/src/core/hooks/queries/friend/useSearchCharacter.ts
@@ -1,0 +1,19 @@
+import { useQuery } from "@tanstack/react-query";
+
+import * as friendApi from "@core/apis/friend.api";
+import type { CommonUseQueryOptions } from "@core/types/app";
+import type { SearchCharacterItem } from "@core/types/friend";
+import queryKeyGenerator from "@core/utils/queryKeyGenerator";
+
+export default (
+  characterName: string,
+  options?: CommonUseQueryOptions<SearchCharacterItem[]>
+) => {
+  const query = useQuery({
+    ...options,
+    queryKey: queryKeyGenerator.searchCharacter(characterName),
+    queryFn: () => friendApi.searchCharacter(characterName),
+  });
+
+  return query;
+};

--- a/src/core/hooks/queries/member/useMyInformation.ts
+++ b/src/core/hooks/queries/member/useMyInformation.ts
@@ -6,7 +6,7 @@ import type { CommonUseQueryOptions } from "@core/types/app";
 import type { Member } from "@core/types/member";
 import queryKeyGenerator from "@core/utils/queryKeyGenerator";
 
-const useMyInformation = (options?: CommonUseQueryOptions<Member>) => {
+export default (options?: CommonUseQueryOptions<Member>) => {
   const query = useQuery({
     ...options,
     queryKey: queryKeyGenerator.getMyInformation(),
@@ -16,5 +16,3 @@ const useMyInformation = (options?: CommonUseQueryOptions<Member>) => {
 
   return query;
 };
-
-export default useMyInformation;

--- a/src/core/hooks/queries/notice/useNotice.ts
+++ b/src/core/hooks/queries/notice/useNotice.ts
@@ -5,7 +5,7 @@ import type { CommonUseQueryOptions } from "@core/types/app";
 import type { NoticeItem } from "@core/types/notice";
 import queryKeyGenerator from "@core/utils/queryKeyGenerator";
 
-const useNotice = (
+export default (
   noticeId: number,
   options?: CommonUseQueryOptions<NoticeItem>
 ) => {
@@ -17,5 +17,3 @@ const useNotice = (
 
   return query;
 };
-
-export default useNotice;

--- a/src/core/hooks/queries/notice/useNotices.ts
+++ b/src/core/hooks/queries/notice/useNotices.ts
@@ -8,7 +8,7 @@ import type {
 } from "@core/types/notice";
 import queryKeyGenerator from "@core/utils/queryKeyGenerator";
 
-const useNotices = (
+export default (
   params: GetNoticeListRequest,
   options?: CommonUseQueryOptions<GetNoticesResponse>
 ) => {
@@ -20,5 +20,3 @@ const useNotices = (
 
   return query;
 };
-
-export default useNotices;

--- a/src/core/hooks/queries/notice/useOfficialNotices.ts
+++ b/src/core/hooks/queries/notice/useOfficialNotices.ts
@@ -8,7 +8,7 @@ import type {
 } from "@core/types/notice";
 import queryKeyGenerator from "@core/utils/queryKeyGenerator";
 
-const useOfficialNotices = (
+export default (
   params: GetNoticeListRequest,
   options?: CommonUseQueryOptions<GetOfficialNoticesResponse>
 ) => {
@@ -20,5 +20,3 @@ const useOfficialNotices = (
 
   return query;
 };
-
-export default useOfficialNotices;

--- a/src/core/hooks/useAuthActions.ts
+++ b/src/core/hooks/useAuthActions.ts
@@ -2,7 +2,7 @@ import { useResetRecoilState, useSetRecoilState } from "recoil";
 
 import { authAtom } from "@core/atoms/auth.atom";
 
-const useAuthActions = () => {
+export default () => {
   const innerSetAuth = useSetRecoilState(authAtom);
   const innerSesetAuth = useResetRecoilState(authAtom);
 
@@ -27,5 +27,3 @@ const useAuthActions = () => {
 
   return { setAuth, resetAuth };
 };
-
-export default useAuthActions;

--- a/src/core/hooks/useModalState.ts
+++ b/src/core/hooks/useModalState.ts
@@ -1,6 +1,6 @@
 import { useState } from "react";
 
-const useModalState = <S>(): [S | undefined, (value?: S) => void] => {
+export default <S>(): [S | undefined, (value?: S) => void] => {
   const [state, setInnerState] = useState<S | undefined>(undefined);
 
   const setState = (newState?: S) => {
@@ -9,5 +9,3 @@ const useModalState = <S>(): [S | undefined, (value?: S) => void] => {
 
   return [state, setState];
 };
-
-export default useModalState;

--- a/src/core/hooks/useToastUiDarkMode.ts
+++ b/src/core/hooks/useToastUiDarkMode.ts
@@ -3,7 +3,7 @@ import { useRecoilValue } from "recoil";
 
 import { themeAtom } from "@core/atoms/theme.atom";
 
-const useToastUiDarkMode = () => {
+export default () => {
   const theme = useRecoilValue(themeAtom);
 
   useEffect(() => {
@@ -28,5 +28,3 @@ const useToastUiDarkMode = () => {
     }
   }, [theme]);
 };
-
-export default useToastUiDarkMode;

--- a/src/core/hooks/useWindowSize.ts
+++ b/src/core/hooks/useWindowSize.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 
-const useWindowSize = () => {
+export default () => {
   const [width, setWidth] = useState(window.innerWidth);
   const [height, setHeight] = useState(window.innerHeight);
 
@@ -24,5 +24,3 @@ const useWindowSize = () => {
     height,
   };
 };
-
-export default useWindowSize;

--- a/src/core/types/app.d.ts
+++ b/src/core/types/app.d.ts
@@ -18,7 +18,7 @@ export type CommonUseQueryOptions<T> = Omit<
   "queryKey" | "queryFn"
 >;
 
-export type UseMutationWithParams<
+export type CommonUseMutationOptions<
   Params = void, // 파라미터가 있는 경우에 넣기, 없으면 void
   Response = unknown, // onSuccess 콜백에서 data로 뭔가 하려는 경우에 response type 넣기
   Error = CustomError, // CustomError 외의 에러 타입이 있다면 넣기

--- a/src/core/types/app.d.ts
+++ b/src/core/types/app.d.ts
@@ -20,6 +20,6 @@ export type CommonUseQueryOptions<T> = Omit<
 
 export type CommonUseMutationOptions<
   Params = void, // 파라미터가 있는 경우에 넣기, 없으면 void
-  Response = unknown, // onSuccess 콜백에서 data로 뭔가 하려는 경우에 response type 넣기
+  Response = void, // onSuccess 콜백에서 data로 뭔가 하려는 경우에 response type 넣기
   Error = CustomError, // CustomError 외의 에러 타입이 있다면 넣기
 > = Omit<UseMutationOptions<Response, Error, Params>, "mutationFn">;

--- a/src/core/types/character.d.ts
+++ b/src/core/types/character.d.ts
@@ -3,6 +3,13 @@ export interface GetWeeklyRaidsRequest {
   characterName: string;
 }
 
+export interface UpdateVisibleSettingRequest {
+  characterId: number;
+  characterName: string;
+  value: boolean;
+  name: VisibleSettingName;
+}
+
 export interface Character {
   characterId: number;
   characterClassName: string;
@@ -77,6 +84,8 @@ export interface WeeklyRaid {
 }
 
 export interface Settings {
+  goldCheckVersion: boolean;
+  goldCheckPolicyEnum: string;
   showCharacter: boolean;
   showEpona: boolean;
   showChaos: boolean;
@@ -85,8 +94,6 @@ export interface Settings {
   showWeekEpona: boolean;
   showSilmaelChange: boolean;
   showCubeTicket: boolean;
-  goldCheckVersion: boolean;
-  goldCheckPolicyEnum: string;
 }
 
 export type CubeName = "1금제" | "2금제" | "3금제" | "4금제" | "5금제";
@@ -102,3 +109,8 @@ export interface CubeReward {
   cardExp: number;
   jewelryPrice: number;
 }
+
+export type VisibleSettingName = keyof Omit<
+  Settings,
+  "goldCheckVersion" | "goldCheckPolicyEnum"
+>;

--- a/src/core/types/character.d.ts
+++ b/src/core/types/character.d.ts
@@ -6,11 +6,11 @@ export type Character = {
   itemLevel: number;
   serverName: string;
   sortNumber: number;
-  chaos: DayContentType;
+  chaos: DailyContent;
   chaosCheck: number;
   chaosGauge: number;
   chaosGold: number;
-  guardian: DayContentType;
+  guardian: DailyContent;
   guardianCheck: number;
   guardianGauge: number;
   guardianGold: number;
@@ -44,7 +44,7 @@ export type Todo = {
   goldCheck: boolean;
 };
 
-export type DayContentType = {
+export type DailyContent = {
   id: number;
   category: string;
   characterClassName: string;
@@ -58,7 +58,7 @@ export type DayContentType = {
   jewelry: number;
 };
 
-export type WeekContnetType = {
+export type WeeklyRaid = {
   id: number;
   weekCategory: string;
   weekContentCategory: string;

--- a/src/core/types/character.d.ts
+++ b/src/core/types/character.d.ts
@@ -1,4 +1,4 @@
-export type CharacterType = {
+export type Character = {
   characterId: number;
   characterClassName: string;
   characterImage: string;

--- a/src/core/types/character.d.ts
+++ b/src/core/types/character.d.ts
@@ -26,10 +26,10 @@ export type CharacterType = {
   cubeTicket: number;
   weekDayTodoGold: number;
   weekRaidGold: number;
-  todoList: TodoType[];
+  todoList: Todo[];
 };
 
-export type TodoType = {
+export type Todo = {
   id: number;
   name: string;
   characterClassName: string;

--- a/src/core/types/character.d.ts
+++ b/src/core/types/character.d.ts
@@ -1,4 +1,9 @@
-export type Character = {
+export interface GetWeeklyRaidsRequest {
+  characterId: number;
+  characterName: string;
+}
+
+export interface Character {
   characterId: number;
   characterClassName: string;
   characterImage: string;
@@ -27,9 +32,9 @@ export type Character = {
   weekDayTodoGold: number;
   weekRaidGold: number;
   todoList: Todo[];
-};
+}
 
-export type Todo = {
+export interface Todo {
   id: number;
   name: string;
   characterClassName: string;
@@ -42,9 +47,9 @@ export type Todo = {
   weekContentCategory: string;
   sortNumber: number;
   goldCheck: boolean;
-};
+}
 
-export type DailyContent = {
+export interface DailyContent {
   id: number;
   category: string;
   characterClassName: string;
@@ -56,9 +61,9 @@ export type DailyContent = {
   destructionStone: number;
   guardianStone: number;
   jewelry: number;
-};
+}
 
-export type WeeklyRaid = {
+export interface WeeklyRaid {
   id: number;
   weekCategory: string;
   weekContentCategory: string;
@@ -69,9 +74,9 @@ export type WeeklyRaid = {
   checked: boolean;
   coolTime: number;
   goldCheck: boolean;
-};
+}
 
-export type Settings = {
+export interface Settings {
   showCharacter: boolean;
   showEpona: boolean;
   showChaos: boolean;
@@ -82,7 +87,7 @@ export type Settings = {
   showCubeTicket: boolean;
   goldCheckVersion: boolean;
   goldCheckPolicyEnum: string;
-};
+}
 
 export type CubeName = "1금제" | "2금제" | "3금제" | "4금제" | "5금제";
 

--- a/src/core/types/friend.d.ts
+++ b/src/core/types/friend.d.ts
@@ -1,6 +1,6 @@
 import { Character } from "./character";
 
-export type FriendType = {
+export type Friend = {
   friendId: number;
   friendUsername: string;
   areWeFriend: string;

--- a/src/core/types/friend.d.ts
+++ b/src/core/types/friend.d.ts
@@ -1,6 +1,11 @@
 import { Character } from "./character";
 
-export type Friend = {
+export interface GetFriendWeeklyRaidsRequest {
+  friendUsername: string;
+  characterId: number;
+}
+
+export interface Friend {
   friendId: number;
   friendUsername: string;
   areWeFriend: string;
@@ -8,9 +13,9 @@ export type Friend = {
   characterList: Character[];
   toFriendSettings: FriendSettings;
   fromFriendSettings: FriendSettings;
-};
+}
 
-export type FriendSettings = {
+export interface FriendSettings {
   showDayTodo: boolean;
   showRaid: boolean;
   showWeekTodo: boolean;
@@ -20,12 +25,12 @@ export type FriendSettings = {
   updateGauge: boolean;
   updateRaid: boolean;
   setting: boolean;
-};
+}
 
-export type SearchCharacterItem = {
+export interface SearchCharacterItem {
   id: number;
   areWeFriend: string;
   characterListSize: number;
   characterName: string;
   username: string;
-};
+}

--- a/src/core/types/friend.d.ts
+++ b/src/core/types/friend.d.ts
@@ -21,3 +21,11 @@ export type FriendSettings = {
   updateRaid: boolean;
   setting: boolean;
 };
+
+export type SearchCharacterItem = {
+  id: number;
+  areWeFriend: string;
+  characterListSize: number;
+  characterName: string;
+  username: string;
+};

--- a/src/core/types/friend.d.ts
+++ b/src/core/types/friend.d.ts
@@ -1,11 +1,11 @@
-import { CharacterType } from "./character";
+import { Character } from "./character";
 
 export type FriendType = {
   friendId: number;
   friendUsername: string;
   areWeFriend: string;
   nickName: string;
-  characterList: CharacterType[];
+  characterList: Character[];
   toFriendSettings: FriendSettings;
   fromFriendSettings: FriendSettings;
 };

--- a/src/core/types/member.d.ts
+++ b/src/core/types/member.d.ts
@@ -19,5 +19,4 @@ export type UpdateMainCharacterRequest = {
 
 export interface UpdateApiKeyRequest {
   apiKey: string;
-  characterName: string;
 }

--- a/src/core/types/notice.d.ts
+++ b/src/core/types/notice.d.ts
@@ -6,7 +6,7 @@ export interface GetNoticeListRequest {
 }
 
 export interface GetNoticesResponse {
-  boardResponseDtoList: BoardType[];
+  boardResponseDtoList: NoticeItem[];
   totalPages: number;
   page: number;
 }

--- a/src/core/utils/queryKeyGenerator.ts
+++ b/src/core/utils/queryKeyGenerator.ts
@@ -7,6 +7,7 @@ import type { GetNoticeListRequest } from "@core/types/notice";
 const defaultKeys = {
   GET_MY_INFORMATION: "GET_MY_INFORMATION",
   GET_FRIENDS: "GET_FRIENDS",
+  SEARCH_CHARACTER: "SEARCH_CHARACTER",
   GET_CHARACTERS: "GET_CHARACTERS",
   GET_CUBE_REWARD: "GET_CUBE_REWARD",
   GET_COMMENTS: "GET_COMMENTS",
@@ -28,6 +29,9 @@ const queryKeyGenerator = {
   },
   getFriends: () => {
     return withParamGenerator(defaultKeys.GET_FRIENDS);
+  },
+  searchCharacter: (characterName?: string) => {
+    return withParamGenerator(defaultKeys.SEARCH_CHARACTER, characterName);
   },
   getCharacters: () => {
     return withParamGenerator(defaultKeys.GET_CHARACTERS);

--- a/src/core/utils/queryKeyGenerator.ts
+++ b/src/core/utils/queryKeyGenerator.ts
@@ -1,15 +1,18 @@
 import type { QueryKey } from "@tanstack/react-query";
 
-import type { CubeName } from "@core/types/character";
+import type { CubeName, GetWeeklyRaidsRequest } from "@core/types/character";
 import type { GetCommentsRequest } from "@core/types/comment";
+import type { GetFriendWeeklyRaidsRequest } from "@core/types/friend";
 import type { GetNoticeListRequest } from "@core/types/notice";
 
 const defaultKeys = {
   GET_MY_INFORMATION: "GET_MY_INFORMATION",
-  GET_FRIENDS: "GET_FRIENDS",
-  SEARCH_CHARACTER: "SEARCH_CHARACTER",
   GET_CHARACTERS: "GET_CHARACTERS",
+  GET_WEEKLY_RAIDS: "GET_WEEKLY_RAIDS",
   GET_CUBE_REWARD: "GET_CUBE_REWARD",
+  GET_FRIENDS: "GET_FRIENDS",
+  GET_FRIEND_WEEKLY_RAIDS: "GET_FRIEND_WEEKLY_RAIDS",
+  SEARCH_CHARACTER: "SEARCH_CHARACTER",
   GET_COMMENTS: "GET_COMMENTS",
   GET_OFFICIAL_NOTICES: "GET_OFFICIAL_NOTICES",
   GET_NOTICES: "GET_NOTICES",
@@ -27,17 +30,23 @@ const queryKeyGenerator = {
   getMyInformation: () => {
     return withParamGenerator(defaultKeys.GET_MY_INFORMATION);
   },
-  getFriends: () => {
-    return withParamGenerator(defaultKeys.GET_FRIENDS);
-  },
   searchCharacter: (characterName?: string) => {
     return withParamGenerator(defaultKeys.SEARCH_CHARACTER, characterName);
   },
   getCharacters: () => {
     return withParamGenerator(defaultKeys.GET_CHARACTERS);
   },
+  getWeeklyRaids: (params?: GetWeeklyRaidsRequest) => {
+    return withParamGenerator(defaultKeys.GET_WEEKLY_RAIDS, params);
+  },
   getCubeReward: (name?: CubeName) => {
     return withParamGenerator(defaultKeys.GET_CUBE_REWARD, name);
+  },
+  getFriends: () => {
+    return withParamGenerator(defaultKeys.GET_FRIENDS);
+  },
+  getFriendWeeklyRaid: (params?: GetFriendWeeklyRaidsRequest) => {
+    return withParamGenerator(defaultKeys.GET_FRIEND_WEEKLY_RAIDS, params);
   },
   getComments: (params?: GetCommentsRequest) => {
     return withParamGenerator(defaultKeys.GET_COMMENTS, params);

--- a/src/core/utils/todo.util.ts
+++ b/src/core/utils/todo.util.ts
@@ -1,5 +1,5 @@
 import { RAID_SORT_ORDER } from "@core/constants";
-import { CharacterType, TodoType } from "@core/types/character";
+import { CharacterType, Todo } from "@core/types/character";
 import { Member } from "@core/types/member";
 
 // 일일 숙제의 총 수를 계산하는 함수
@@ -109,7 +109,7 @@ export const getDefaultServer = (
 export const calculateRaidStatus = (characters: CharacterType[]) => {
   const todoListGroupedByWeekCategory = characters
     .flatMap((character) => character.todoList)
-    .reduce<{ [key: string]: TodoType[] }>((acc, todo) => {
+    .reduce<{ [key: string]: Todo[] }>((acc, todo) => {
       const newAcc = { ...acc };
 
       newAcc[todo.weekCategory] = newAcc[todo.weekCategory] || [];
@@ -153,7 +153,7 @@ export const calculateRaidStatus = (characters: CharacterType[]) => {
 export const calculateFriendRaids = (characters: CharacterType[]) => {
   const todoListGroupedByWeekCategory = characters
     .flatMap((character) => character.todoList)
-    .reduce<{ [key: string]: TodoType[] }>((acc, todo) => {
+    .reduce<{ [key: string]: Todo[] }>((acc, todo) => {
       const newAcc = { ...acc };
 
       newAcc[todo.weekCategory] = newAcc[todo.weekCategory] || [];

--- a/src/core/utils/todo.util.ts
+++ b/src/core/utils/todo.util.ts
@@ -1,9 +1,9 @@
 import { RAID_SORT_ORDER } from "@core/constants";
-import { CharacterType, Todo } from "@core/types/character";
+import { Character, Todo } from "@core/types/character";
 import { Member } from "@core/types/member";
 
 // 일일 숙제의 총 수를 계산하는 함수
-export const getTotalDayTodos = (characters: CharacterType[]): number => {
+export const getTotalDayTodos = (characters: Character[]): number => {
   return characters.reduce((acc, character) => {
     let newAcc = acc;
 
@@ -20,7 +20,7 @@ export const getTotalDayTodos = (characters: CharacterType[]): number => {
 };
 
 // 일일 숙제를 완료한 수를 계산하는 함수
-export const getCompletedDayTodos = (characters: CharacterType[]): number => {
+export const getCompletedDayTodos = (characters: Character[]): number => {
   return characters.reduce((acc, character) => {
     let newAcc = acc;
 
@@ -37,7 +37,7 @@ export const getCompletedDayTodos = (characters: CharacterType[]): number => {
 };
 
 // 주간 숙제의 총 수를 계산하는 함수
-export const getTotalWeekTodos = (characters: CharacterType[]): number => {
+export const getTotalWeekTodos = (characters: Character[]): number => {
   return characters.reduce((acc, character) => {
     let newAcc = acc;
 
@@ -51,7 +51,7 @@ export const getTotalWeekTodos = (characters: CharacterType[]): number => {
 };
 
 // 주간 숙제를 완료한 수를 계산하는 함수
-export const getCompletedWeekTodos = (characters: CharacterType[]): number => {
+export const getCompletedWeekTodos = (characters: Character[]): number => {
   return characters.reduce((acc, character) => {
     let newAcc = acc;
 
@@ -67,9 +67,9 @@ export const getCompletedWeekTodos = (characters: CharacterType[]): number => {
 };
 
 export const getCharactersByServer = (
-  characters: CharacterType[],
+  characters: Character[],
   serverName: string | null
-): CharacterType[] => {
+): Character[] => {
   if (serverName === "" || serverName === undefined || serverName === null) {
     const serverCounts = getServerList(characters);
     const maxCountServerName = Array.from(serverCounts.entries()).reduce(
@@ -84,9 +84,7 @@ export const getCharactersByServer = (
   return characters.filter((character) => character.serverName === serverName);
 };
 
-export const getServerList = (
-  characters: CharacterType[]
-): Map<string, number> => {
+export const getServerList = (characters: Character[]): Map<string, number> => {
   const serverCounts = new Map<string, number>();
   characters.forEach((character) => {
     const count = serverCounts.get(character.serverName) || 0;
@@ -96,7 +94,7 @@ export const getServerList = (
 };
 
 export const getDefaultServer = (
-  characters: CharacterType[],
+  characters: Character[],
   member: Member
 ): string => {
   if (member.mainCharacter.serverName !== null) {
@@ -106,7 +104,7 @@ export const getDefaultServer = (
   return findManyCharactersServer(characters);
 };
 
-export const calculateRaidStatus = (characters: CharacterType[]) => {
+export const calculateRaidStatus = (characters: Character[]) => {
   const todoListGroupedByWeekCategory = characters
     .flatMap((character) => character.todoList)
     .reduce<{ [key: string]: Todo[] }>((acc, todo) => {
@@ -150,7 +148,7 @@ export const calculateRaidStatus = (characters: CharacterType[]) => {
   return raidStatus.filter((raid) => raid.totalCount >= 1);
 };
 
-export const calculateFriendRaids = (characters: CharacterType[]) => {
+export const calculateFriendRaids = (characters: Character[]) => {
   const todoListGroupedByWeekCategory = characters
     .flatMap((character) => character.todoList)
     .reduce<{ [key: string]: Todo[] }>((acc, todo) => {
@@ -194,9 +192,7 @@ export const calculateFriendRaids = (characters: CharacterType[]) => {
   return raidStatus;
 };
 
-export const findManyCharactersServer = (
-  characters: CharacterType[]
-): string => {
+export const findManyCharactersServer = (characters: Character[]): string => {
   const serverCounts = getServerList(characters);
   return Array.from(serverCounts.entries()).reduce((a, b) =>
     b[1] > a[1] ? b : a

--- a/src/pages/friends/FriendTodo.tsx
+++ b/src/pages/friends/FriendTodo.tsx
@@ -7,7 +7,7 @@ import DefaultLayout from "@layouts/DefaultLayout";
 
 import { sortForm } from "@core/atoms/sortForm.atom";
 import useFriends from "@core/hooks/queries/friend/useFriends";
-import { CharacterType } from "@core/types/character";
+import { Character } from "@core/types/character";
 import { FriendType } from "@core/types/friend";
 import { findManyCharactersServer, getServerList } from "@core/utils/todo.util";
 
@@ -24,8 +24,8 @@ const FriendTodo = () => {
   const showSortForm = useRecoilValue(sortForm);
 
   const getFriends = useFriends();
-  const [characters, setCharacters] = useState<CharacterType[]>([]);
-  const [serverCharacters, setServerCharacters] = useState<CharacterType[]>([]);
+  const [characters, setCharacters] = useState<Character[]>([]);
+  const [serverCharacters, setServerCharacters] = useState<Character[]>([]);
   const [serverList, setServerList] = useState(new Map());
   const [friend, setFriend] = useState<FriendType>();
   const [server, setServer] = useState("");

--- a/src/pages/friends/FriendTodo.tsx
+++ b/src/pages/friends/FriendTodo.tsx
@@ -8,7 +8,7 @@ import DefaultLayout from "@layouts/DefaultLayout";
 import { sortForm } from "@core/atoms/sortForm.atom";
 import useFriends from "@core/hooks/queries/friend/useFriends";
 import { Character } from "@core/types/character";
-import { FriendType } from "@core/types/friend";
+import { Friend } from "@core/types/friend";
 import { findManyCharactersServer, getServerList } from "@core/utils/todo.util";
 
 import Dial from "@components/Dial";
@@ -27,7 +27,7 @@ const FriendTodo = () => {
   const [characters, setCharacters] = useState<Character[]>([]);
   const [serverCharacters, setServerCharacters] = useState<Character[]>([]);
   const [serverList, setServerList] = useState(new Map());
-  const [friend, setFriend] = useState<FriendType>();
+  const [friend, setFriend] = useState<Friend>();
   const [server, setServer] = useState("");
 
   useEffect(() => {

--- a/src/pages/friends/FriendsIndex.tsx
+++ b/src/pages/friends/FriendsIndex.tsx
@@ -13,7 +13,7 @@ import useRemoveFriend from "@core/hooks/mutations/friend/useRemoveFriend";
 import useCharacters from "@core/hooks/queries/character/useCharacters";
 import useFriends from "@core/hooks/queries/friend/useFriends";
 import useModalState from "@core/hooks/useModalState";
-import { FriendType } from "@core/types/friend";
+import { Friend } from "@core/types/friend";
 import queryKeyGenerator from "@core/utils/queryKeyGenerator";
 import { calculateFriendRaids } from "@core/utils/todo.util";
 
@@ -40,7 +40,7 @@ const TABLE_COLUMNS = [
 const FriendsIndex = () => {
   const queryClient = useQueryClient();
 
-  const [modalState, setModalState] = useModalState<FriendType>();
+  const [modalState, setModalState] = useModalState<Friend>();
   const getFriends = useFriends();
   const getCharacters = useCharacters();
 

--- a/src/pages/friends/components/AddFriendButton.tsx
+++ b/src/pages/friends/components/AddFriendButton.tsx
@@ -8,10 +8,10 @@ import { toast } from "react-toastify";
 import { useRecoilState } from "recoil";
 
 import * as friendApi from "@core/apis/friend.api";
-import type { SearchCharacterResponseType } from "@core/apis/friend.api";
 import { loading } from "@core/atoms/loading.atom";
 import useCharacters from "@core/hooks/queries/character/useCharacters";
 import useModalState from "@core/hooks/useModalState";
+import type { SearchCharacterItem } from "@core/types/friend";
 import queryKeyGenerator from "@core/utils/queryKeyGenerator";
 
 import Modal from "@components/Modal";
@@ -24,7 +24,7 @@ const FriendAddBtn = () => {
   const [loadingState, setLoadingState] = useRecoilState(loading);
   const [searchUserModal, setSearchUserModal] = useModalState<boolean>();
   const [searchResultModal, setSearchResultModal] =
-    useModalState<SearchCharacterResponseType[]>();
+    useModalState<SearchCharacterItem[]>();
 
   const getCharacters = useCharacters();
 

--- a/src/pages/friends/components/AddFriendButton.tsx
+++ b/src/pages/friends/components/AddFriendButton.tsx
@@ -2,105 +2,46 @@ import styled from "@emotion/styled";
 import { Button } from "@mui/material";
 import { MdGroupAdd } from "@react-icons/all-files/md/MdGroupAdd";
 import { MdSearch } from "@react-icons/all-files/md/MdSearch";
-import { useQueryClient } from "@tanstack/react-query";
 import { useRef } from "react";
 import { toast } from "react-toastify";
-import { useRecoilState } from "recoil";
 
-import * as friendApi from "@core/apis/friend.api";
-import { loading } from "@core/atoms/loading.atom";
 import useCharacters from "@core/hooks/queries/character/useCharacters";
 import useModalState from "@core/hooks/useModalState";
-import type { SearchCharacterItem } from "@core/types/friend";
-import queryKeyGenerator from "@core/utils/queryKeyGenerator";
 
 import Modal from "@components/Modal";
 
-const FriendAddBtn = () => {
-  const queryClient = useQueryClient();
+import SearchResultModal from "./SearchResultModal";
 
+const FriendAddBtn = () => {
   const searchInputRef = useRef<HTMLInputElement>(null);
 
-  const [loadingState, setLoadingState] = useRecoilState(loading);
   const [searchUserModal, setSearchUserModal] = useModalState<boolean>();
-  const [searchResultModal, setSearchResultModal] =
-    useModalState<SearchCharacterItem[]>();
+  const [searchTerm, setSearchTerm] = useModalState<string>();
 
   const getCharacters = useCharacters();
 
   const searchFriend = async () => {
-    try {
-      setLoadingState(true);
-      const searchName = searchInputRef.current?.value || "";
-      if (searchName === "") {
-        toast("캐릭터 명을 입력하여주십시오.");
-      } else {
-        const response = await friendApi.searchCharacter(searchName);
-        if (searchInputRef.current) {
-          searchInputRef.current.value = "";
-        }
-        setSearchUserModal();
-        setSearchResultModal(response);
+    const searchName = searchInputRef.current?.value || "";
+
+    if (searchName === "") {
+      toast("캐릭터 명을 입력하여주십시오.");
+    } else {
+      if (searchInputRef.current) {
+        searchInputRef.current.value = "";
       }
-    } catch (error) {
-      console.error(error);
-    } finally {
-      setLoadingState(false);
-    }
-  };
-
-  // 검색 후 요청 메서드
-  const requestFriend = async (category: string, fromMember: string) => {
-    if (category === "깐부 요청") {
-      const response = await friendApi.requestFriend(fromMember);
-
-      if (response) {
-        setSearchResultModal();
-        queryClient.invalidateQueries({
-          queryKey: queryKeyGenerator.getFriends(),
-        });
-        toast("요청이 정상적으로 처리되었습니다.");
-      }
-    }
-    if (
-      category === "깐부 요청 진행중" ||
-      category === "깐부 요청 받음" ||
-      category === "요청 거부"
-    ) {
-      handleRequest("delete", fromMember);
-    }
-  };
-
-  const handleRequest = async (category: string, fromMember: string) => {
-    const confirmMessage =
-      category === "delete" ? "해당 요청을 삭제 하시겠습니까?" : null;
-
-    const userConfirmed = confirmMessage
-      ? window.confirm(confirmMessage)
-      : true;
-
-    if (userConfirmed) {
-      const response = await friendApi.handleRequest(category, fromMember);
-      if (response) {
-        setSearchResultModal();
-        toast("요청이 정상적으로 처리되었습니다.");
-        queryClient.invalidateQueries({
-          queryKey: queryKeyGenerator.getFriends(),
-        });
-      }
+      setSearchUserModal();
+      setSearchTerm(searchName);
     }
   };
 
   if (!getCharacters.data || getCharacters.data.length === 0) {
     return null;
   }
-
   return (
     <>
       <AddButton
         variant="text"
         startIcon={<MdGroupAdd />}
-        disabled={loadingState}
         onClick={() => setSearchUserModal(true)}
       >
         깐부 추가
@@ -125,80 +66,11 @@ const FriendAddBtn = () => {
         </SearchUserWrapper>
       </Modal>
 
-      {searchResultModal && (
-        <Modal
-          title="캐릭터 검색 결과"
-          isOpen={!!searchResultModal}
-          onClose={() => setSearchResultModal()}
-        >
-          <SearchResultWrapper>
-            {searchResultModal.map((character) => {
-              return (
-                <SearchResultRow key={character.id}>
-                  {character.username.substring(0, 5) +
-                    "*".repeat(character.username.length - 5)}
-
-                  {(() => {
-                    switch (character.areWeFriend) {
-                      case "깐부 요청 진행중":
-                        return (
-                          <Button
-                            focusRipple={false}
-                            color="secondary"
-                            onClick={() =>
-                              requestFriend(
-                                character.areWeFriend,
-                                character.username
-                              )
-                            }
-                          >
-                            {character.areWeFriend}
-                          </Button>
-                        );
-
-                      case "깐부 요청 받음":
-                        return (
-                          <Button
-                            focusRipple={false}
-                            color="success"
-                            onClick={() =>
-                              requestFriend(
-                                character.areWeFriend,
-                                character.username
-                              )
-                            }
-                          >
-                            {character.areWeFriend}
-                          </Button>
-                        );
-                      case "깐부":
-                        return (
-                          <Button disabled>{character.areWeFriend}</Button>
-                        );
-                      case "깐부 요청":
-                        return (
-                          <Button
-                            focusRipple={false}
-                            onClick={() =>
-                              requestFriend(
-                                character.areWeFriend,
-                                character.username
-                              )
-                            }
-                          >
-                            {character.areWeFriend}
-                          </Button>
-                        );
-                      default:
-                        return null;
-                    }
-                  })()}
-                </SearchResultRow>
-              );
-            })}
-          </SearchResultWrapper>
-        </Modal>
-      )}
+      <SearchResultModal
+        onClose={() => setSearchTerm(undefined)}
+        isOpen={!!searchTerm}
+        searchTerm={searchTerm || ""}
+      />
     </>
   );
 };
@@ -240,23 +112,4 @@ const Input = styled.input`
 const SearchButton = styled(Button)`
   padding: 10px;
   color: ${({ theme }) => theme.app.text.dark2};
-`;
-
-const SearchResultWrapper = styled.div`
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 5px;
-`;
-
-const SearchResultRow = styled.div`
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  gap: 10px;
-  color: ${({ theme }) => theme.app.text.dark2};
-
-  & + & {
-    margin-top: 10px;
-  }
 `;

--- a/src/pages/friends/components/SearchResultModal.tsx
+++ b/src/pages/friends/components/SearchResultModal.tsx
@@ -1,0 +1,154 @@
+import styled from "@emotion/styled";
+import { Button } from "@mui/material";
+import { useQueryClient } from "@tanstack/react-query";
+import { toast } from "react-toastify";
+
+import * as friendApi from "@core/apis/friend.api";
+import useSearchCharacter from "@core/hooks/queries/friend/useSearchCharacter";
+import queryKeyGenerator from "@core/utils/queryKeyGenerator";
+
+import Modal from "@components/Modal";
+
+interface Props {
+  onClose: () => void;
+  isOpen: boolean;
+  searchTerm: string;
+}
+
+const SearchResultModal = ({ onClose, isOpen, searchTerm }: Props) => {
+  const queryClient = useQueryClient();
+
+  const searchCharacter = useSearchCharacter(searchTerm, {
+    enabled: !!searchTerm,
+  });
+
+  const handleRequest = async (category: string, fromMember: string) => {
+    const confirmMessage =
+      category === "delete" ? "해당 요청을 삭제 하시겠습니까?" : null;
+
+    const userConfirmed = confirmMessage
+      ? window.confirm(confirmMessage)
+      : true;
+
+    if (userConfirmed) {
+      const response = await friendApi.handleRequest(category, fromMember);
+      if (response) {
+        toast.success("요청이 정상적으로 처리되었습니다.");
+        queryClient.invalidateQueries({
+          queryKey: queryKeyGenerator.getFriends(),
+        });
+        onClose();
+      }
+    }
+  };
+
+  const requestFriend = async (category: string, fromMember: string) => {
+    if (category === "깐부 요청") {
+      const response = await friendApi.requestFriend(fromMember);
+
+      if (response) {
+        queryClient.invalidateQueries({
+          queryKey: queryKeyGenerator.getFriends(),
+        });
+        toast.success("요청이 정상적으로 처리되었습니다.");
+        onClose();
+      }
+    } else if (
+      category === "깐부 요청 진행중" ||
+      category === "깐부 요청 받음" ||
+      category === "요청 거부"
+    ) {
+      handleRequest("delete", fromMember);
+    }
+  };
+
+  return (
+    <Modal title="캐릭터 검색 결과" isOpen={isOpen} onClose={onClose}>
+      <Wrapper>
+        {searchCharacter.data?.map((character) => {
+          return (
+            <Row key={character.id}>
+              {character.username.substring(0, 5) +
+                "*".repeat(character.username.length - 5)}
+
+              {(() => {
+                switch (character.areWeFriend) {
+                  case "깐부 요청 진행중":
+                    return (
+                      <Button
+                        focusRipple={false}
+                        color="secondary"
+                        onClick={() =>
+                          requestFriend(
+                            character.areWeFriend,
+                            character.username
+                          )
+                        }
+                      >
+                        {character.areWeFriend}
+                      </Button>
+                    );
+
+                  case "깐부 요청 받음":
+                    return (
+                      <Button
+                        focusRipple={false}
+                        color="success"
+                        onClick={() =>
+                          requestFriend(
+                            character.areWeFriend,
+                            character.username
+                          )
+                        }
+                      >
+                        {character.areWeFriend}
+                      </Button>
+                    );
+                  case "깐부":
+                    return <Button disabled>{character.areWeFriend}</Button>;
+                  case "깐부 요청":
+                    return (
+                      <Button
+                        focusRipple={false}
+                        onClick={() =>
+                          requestFriend(
+                            character.areWeFriend,
+                            character.username
+                          )
+                        }
+                      >
+                        {character.areWeFriend}
+                      </Button>
+                    );
+                  default:
+                    return null;
+                }
+              })()}
+            </Row>
+          );
+        })}
+      </Wrapper>
+    </Modal>
+  );
+};
+
+export default SearchResultModal;
+
+const Wrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 5px;
+`;
+
+const Row = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 10px;
+  color: ${({ theme }) => theme.app.text.dark2};
+
+  & + & {
+    margin-top: 10px;
+  }
+`;

--- a/src/pages/home/HomeIndex.tsx
+++ b/src/pages/home/HomeIndex.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from "react";
 import DefaultLayout from "@layouts/DefaultLayout";
 
 import useCharacters from "@core/hooks/queries/character/useCharacters";
-import { CharacterType } from "@core/types/character";
+import { Character } from "@core/types/character";
 
 import TestDataNotify from "@components/TestDataNotify";
 
@@ -17,9 +17,7 @@ import MainWeekly from "./components/MainWeekly";
 
 const HomeIndex = () => {
   const getCharacters = useCharacters();
-  const [visibleCharacters, setVisibleCharacters] = useState<CharacterType[]>(
-    []
-  );
+  const [visibleCharacters, setVisibleCharacters] = useState<Character[]>([]);
 
   useEffect(() => {
     if (getCharacters.data) {

--- a/src/pages/home/components/MainCharacters.tsx
+++ b/src/pages/home/components/MainCharacters.tsx
@@ -5,7 +5,7 @@ import type { FC } from "react";
 import useUpdateMainCharacter from "@core/hooks/mutations/member/useUpdateMainCharacter";
 import useMyInformation from "@core/hooks/queries/member/useMyInformation";
 import useModalState from "@core/hooks/useModalState";
-import { CharacterType } from "@core/types/character";
+import { Character } from "@core/types/character";
 import queryKeyGenerator from "@core/utils/queryKeyGenerator";
 
 import Button from "@components/Button";
@@ -15,14 +15,14 @@ import BoxTitle from "./BoxTitle";
 import BoxWrapper from "./BoxWrapper";
 
 interface Props {
-  characters: CharacterType[];
+  characters: Character[];
 }
 
 const MainCharacters: FC<Props> = ({ characters }) => {
   const queryClient = useQueryClient();
 
   const [targetRepresentCharacter, toggleTargetRepresentCharacter] =
-    useModalState<CharacterType>();
+    useModalState<Character>();
 
   const getMyInformation = useMyInformation();
   const updateMainCharacter = useUpdateMainCharacter({

--- a/src/pages/home/components/MainProfit.tsx
+++ b/src/pages/home/components/MainProfit.tsx
@@ -1,13 +1,13 @@
 import styled from "@emotion/styled";
 import { FC } from "react";
 
-import { CharacterType } from "@core/types/character";
+import { Character } from "@core/types/character";
 
 import BoxTitle from "./BoxTitle";
 import BoxWrapper from "./BoxWrapper";
 
 interface Props {
-  characters: CharacterType[];
+  characters: Character[];
 }
 
 const MainProfit: FC<Props> = ({ characters }) => {

--- a/src/pages/home/components/MainRaids.tsx
+++ b/src/pages/home/components/MainRaids.tsx
@@ -3,7 +3,7 @@ import { FC } from "react";
 import { useNavigate } from "react-router-dom";
 
 import { Character } from "@core/types/character";
-import { FriendType } from "@core/types/friend";
+import { Friend } from "@core/types/friend";
 import { calculateRaidStatus } from "@core/utils/todo.util";
 
 import Button from "@components/Button";
@@ -13,7 +13,7 @@ import BoxWrapper from "./BoxWrapper";
 
 interface Props {
   characters: Character[];
-  friend?: FriendType;
+  friend?: Friend;
 }
 
 const MainRaids: FC<Props> = ({ characters, friend }) => {

--- a/src/pages/home/components/MainRaids.tsx
+++ b/src/pages/home/components/MainRaids.tsx
@@ -2,7 +2,7 @@ import styled from "@emotion/styled";
 import { FC } from "react";
 import { useNavigate } from "react-router-dom";
 
-import { CharacterType } from "@core/types/character";
+import { Character } from "@core/types/character";
 import { FriendType } from "@core/types/friend";
 import { calculateRaidStatus } from "@core/utils/todo.util";
 
@@ -12,7 +12,7 @@ import BoxTitle from "./BoxTitle";
 import BoxWrapper from "./BoxWrapper";
 
 interface Props {
-  characters: CharacterType[];
+  characters: Character[];
   friend?: FriendType;
 }
 

--- a/src/pages/member/ApiKeyUpdateForm.tsx
+++ b/src/pages/member/ApiKeyUpdateForm.tsx
@@ -27,9 +27,6 @@ const ApiKeyUpdateForm = () => {
   const [apiKey, setApiKey] = useState("");
   const [apiKeyMessage, setApiKeyMessage] = useState("");
 
-  const [character, setCharacter] = useState("");
-  const [characterMessage, setCharacterMessage] = useState("");
-
   const updateApiKey = useUpdateApiKey({
     onSuccess: () => {
       queryClient.invalidateQueries({
@@ -47,21 +44,17 @@ const ApiKeyUpdateForm = () => {
   // 메시지 리셋
   const messageReset = () => {
     setApiKeyMessage("");
-    setCharacterMessage("");
   };
 
   // 유효성 검사
   const validation = (): boolean => {
     let isValid = true;
 
-    if (!apiKey || !character) {
+    if (!apiKey) {
       isValid = false;
 
       if (!apiKey) {
         setApiKeyMessage("ApiKey를 입력해주세요.");
-      }
-      if (!character) {
-        setCharacterMessage("대표캐릭터를 입력해주세요.");
       }
     }
 
@@ -76,7 +69,6 @@ const ApiKeyUpdateForm = () => {
     if (validation()) {
       updateApiKey.mutate({
         apiKey,
-        characterName: character,
       });
     }
   };
@@ -98,19 +90,6 @@ const ApiKeyUpdateForm = () => {
               }
             }}
             message={apiKeyMessage}
-          />
-          <InputBox
-            ref={characterInputRef}
-            type="text"
-            placeholder="대표 캐릭터"
-            value={character}
-            setValue={setCharacter}
-            onKeyDown={(e) => {
-              if (e.key === "Enter") {
-                formRef.current?.requestSubmit();
-              }
-            }}
-            message={characterMessage}
           />
 
           <SubmitButton>API KEY 업데이트</SubmitButton>

--- a/src/pages/todo/TodoAllIndex.tsx
+++ b/src/pages/todo/TodoAllIndex.tsx
@@ -6,7 +6,7 @@ import DefaultLayout from "@layouts/DefaultLayout";
 
 import { sortForm } from "@core/atoms/sortForm.atom";
 import useCharacters from "@core/hooks/queries/character/useCharacters";
-import { CharacterType } from "@core/types/character";
+import { Character } from "@core/types/character";
 
 import Dial from "@components/Dial";
 import SortCharacters from "@components/SortCharacters";
@@ -16,9 +16,7 @@ import TodolList from "@components/todo/TodolList";
 
 const TodoAllIndex = () => {
   const getCharacters = useCharacters();
-  const [visibleCharacters, setVisibleCharacters] = useState<CharacterType[]>(
-    []
-  );
+  const [visibleCharacters, setVisibleCharacters] = useState<Character[]>([]);
   const showSortForm = useRecoilValue(sortForm);
 
   useEffect(() => {

--- a/src/pages/todo/TodoIndex.tsx
+++ b/src/pages/todo/TodoIndex.tsx
@@ -7,7 +7,7 @@ import DefaultLayout from "@layouts/DefaultLayout";
 import { sortForm } from "@core/atoms/sortForm.atom";
 import { serverState } from "@core/atoms/todo.atom";
 import useCharacters from "@core/hooks/queries/character/useCharacters";
-import { CharacterType } from "@core/types/character";
+import { Character } from "@core/types/character";
 import { getServerList } from "@core/utils/todo.util";
 
 import Dial from "@components/Dial";
@@ -20,7 +20,7 @@ import TodoList from "@components/todo/TodolList";
 
 const TodoIndex = () => {
   const getCharacters = useCharacters();
-  const [serverCharacters, setServerCharacters] = useState<CharacterType[]>([]);
+  const [serverCharacters, setServerCharacters] = useState<Character[]>([]);
   const [serverList, setServerList] = useState(new Map());
   const [server, setServer] = useRecoilState(serverState);
   const showSortForm = useRecoilValue(sortForm);


### PR DESCRIPTION
- 타입명 정리 완료 (예. CharacterType -> Character): 첫글자가 대문자인 것 만으로도 타입이라는 것을 구분할 수 있음
- API KEY 변경 페이지에서 대표 캐릭터명을 요구하지 않도록 수정
- WeeklyRaids 컴포넌트에서 편집 모달을 분리했음
- WeeklyRaids 편집 모달 get api react-query로 처리하도록 수정
- 깐부 신청을 위해 검색 시 get api react-query로 처리하도록 수정
- 캐릭터 정보 업데이트 patch api react-query로 처리하도록 수정
- 출력 설정에서 주간레이드를 해제했음에도 WeeklyRaids 컴포넌트의 머리부분만 숨겨지는 현상 수정