### PR TITLE
feat: Add threshold checks for Chaos and Guardian gold calculations

### DIFF
--- a/src/components/todo/Profit.tsx
+++ b/src/components/todo/Profit.tsx
@@ -14,11 +14,17 @@ const Profit: FC<Props> = ({ characters }) => {
   const totalDayGold = characters.reduce((acc, character) => {
     let newAcc = acc;
 
-    if (character.settings.showChaos) {
+    if (
+      character.settings.showChaos &&
+      character.beforeChaosGauge >= character.settings.thresholdChaos
+    ) {
       newAcc += character.chaosGold;
     }
 
-    if (character.settings.showGuardian) {
+    if (
+      character.settings.showGuardian &&
+      character.beforeGuardianGauge >= character.settings.thresholdGuardian
+    ) {
       newAcc += character.guardianGold;
     }
 


### PR DESCRIPTION
- Implemented threshold validation for Chaos Dungeon and Guardian Hunt gold
- Only include gold in total calculation if character's gauge meets or exceeds set threshold
- Ensures more precise gold tracking based on character-specific settings