### PR TITLE
feat: Enhance Weekly Raids component with schedule integration

### DIFF
--- a/src/core/constants/index.ts
+++ b/src/core/constants/index.ts
@@ -1,5 +1,5 @@
-export const BASE_URL = "https://api2.loatodo.com";
-// export const BASE_URL = "http://localhost:8080";
+// export const BASE_URL = "https://api2.loatodo.com";
+export const BASE_URL = "http://localhost:8080";
 
 export const RAID_SORT_ORDER = [
   "강습 타르칼",

--- a/src/pages/schedule/components/FormModal.tsx
+++ b/src/pages/schedule/components/FormModal.tsx
@@ -811,7 +811,7 @@ const Textarea = styled.textarea`
   display: block;
   padding: 4px 8px;
   width: 100%;
-  height: 115px;
+  height: 200px;
   border-radius: 6px;
   font-size: 14px;
   line-height: 1.5;


### PR DESCRIPTION
- Add functionality to filter and display raid schedules for the current week
- Implement a tooltip in RaidItem to show schedule details for each raid
- Introduce a modal for creating and editing schedules linked to raid todos
- Refactor TodoWeekRaid and RaidItem components to accommodate new schedule logic