### PR TITLE
fix: Adjust offset in RaidItem component for improved layout

### DIFF
--- a/src/components/todo/TodoList/WeeklyRaids/RaidItem.tsx
+++ b/src/components/todo/TodoList/WeeklyRaids/RaidItem.tsx
@@ -220,7 +220,7 @@ const RaidItem = forwardRef<HTMLDivElement, Props>(
                 {
                   name: "offset",
                   options: {
-                    offset: [0, -40],
+                    offset: [0, -100],
                   },
                 },
               ],


### PR DESCRIPTION
- Update the offset value from [-40] to [-100] to enhance the positioning of elements in the RaidItem component