### PR TITLE
feat: 스케줄 자동체크 설정 값 추가와 버그수정

### DIFF
--- a/src/components/todo/TodoList/WeeklyRaids/index.tsx
+++ b/src/components/todo/TodoList/WeeklyRaids/index.tsx
@@ -99,6 +99,7 @@ const TodoWeekRaid: FC<Props> = ({ character, friend }) => {
     const map = new Map<string, (typeof filteredSchedules)[number]>();
 
     filteredSchedules.forEach((schedule) => {
+      if (!schedule.autoCheck) return;
       const key = `${schedule.characterName}|${schedule.raidName}`;
       map.set(key, schedule);
     });

--- a/src/components/todo/TodoList/WeeklyRaids/index.tsx
+++ b/src/components/todo/TodoList/WeeklyRaids/index.tsx
@@ -4,11 +4,8 @@ import { useEffect, useMemo, useState } from "react";
 import { toast } from "react-toastify";
 import styled from "styled-components";
 
-import FormModal from "@pages/schedule/components/FormModal";
-
 import { useUpdateRaidTodoSort } from "@core/hooks/mutations/todo";
 import { useSchedulesMonth } from "@core/hooks/queries/schedule";
-import useModalState from "@core/hooks/useModalState";
 import { updateCharacterQueryData } from "@core/lib/queryClient";
 import type { Character, TodoRaid } from "@core/types/character";
 import type { Friend } from "@core/types/friend";
@@ -16,7 +13,6 @@ import type { Friend } from "@core/types/friend";
 import BoxTitle from "@components/BoxTitle";
 import Button from "@components/Button";
 
-import type { ScheduleItem } from "../../../../core/types/schedule";
 import CharacterRaidProfit from "./CharacterRaidProfit";
 import EditModal from "./EditModal";
 import RaidItem from "./RaidItem";
@@ -53,24 +49,16 @@ const TodoWeekRaid: FC<Props> = ({ character, friend }) => {
     month: startDate.month() + 1,
   });
 
-  // 이번 주 수요일
-  const startOfWeek =
-    today.day() >= 3
-      ? today.day(3) // 이번 주 수요일
-      : today.day(-4); // 일~화이면 지난 수요일
-
-  const endOfWeek = startOfWeek.add(6, "day"); // 다음 주 화요일
+  // 이번 주 수요일 ~ 다음 주 화요일 범위 계산
+  const startOfWeek = today.day() >= 3 ? today.day(3) : today.day(-4);
+  const endOfWeek = startOfWeek.add(6, "day");
 
   const filteredSchedules = useMemo(() => {
     if (!getSchedules.data) return [];
 
     return getSchedules.data.filter((schedule) => {
-      if (schedule.scheduleRaidCategory !== "RAID") {
-        return false;
-      }
-
+      if (schedule.scheduleRaidCategory !== "RAID") return false;
       if (schedule.repeatWeek) return true;
-
       if (!schedule.date) return false;
 
       const scheduleDate = dayjs(schedule.date);
@@ -81,6 +69,7 @@ const TodoWeekRaid: FC<Props> = ({ character, friend }) => {
     });
   }, [getSchedules.data, startOfWeek, endOfWeek]);
 
+  // character.todoList 순서대로 초기화
   useEffect(() => {
     setSortedWeeklyRaidTodoList([...character.todoList]);
   }, [sortMode]);
@@ -105,13 +94,24 @@ const TodoWeekRaid: FC<Props> = ({ character, friend }) => {
     return result.join(" ");
   };
 
+  // 스케줄을 Map으로 캐싱
+  const scheduleMap = useMemo(() => {
+    const map = new Map<string, (typeof filteredSchedules)[number]>();
+
+    filteredSchedules.forEach((schedule) => {
+      const key = `${schedule.characterName}|${schedule.raidName}`;
+      map.set(key, schedule);
+    });
+
+    return map;
+  }, [filteredSchedules]);
+
   return (
     <>
       <Wrapper>
         <TitleBox>
           <TitleRow>
             <BoxTitle>주간 레이드</BoxTitle>
-
             <ButtonsBox>
               {sortMode ? (
                 sortedWeeklyRaidTodoList && (
@@ -132,9 +132,7 @@ const TodoWeekRaid: FC<Props> = ({ character, friend }) => {
                 <Button
                   variant="outlined"
                   size="small"
-                  onClick={() => {
-                    setSortMode(true);
-                  }}
+                  onClick={() => setSortMode(true)}
                 >
                   정렬
                 </Button>
@@ -142,9 +140,7 @@ const TodoWeekRaid: FC<Props> = ({ character, friend }) => {
               <Button
                 variant="outlined"
                 size="small"
-                onClick={() => {
-                  setEditModal(true);
-                }}
+                onClick={() => setEditModal(true)}
               >
                 편집
               </Button>
@@ -164,16 +160,15 @@ const TodoWeekRaid: FC<Props> = ({ character, friend }) => {
                 character={character}
                 friend={friend}
                 todoList={sortedWeeklyRaidTodoList}
-                setTodos={(newTodoList) => {
-                  setSortedWeeklyRaidTodoList(newTodoList);
-                }}
+                setTodos={(newTodoList) =>
+                  setSortedWeeklyRaidTodoList(newTodoList)
+                }
               />
             )
           : character.todoList.map((todo) => {
               const raidName = getRaidName(todo.name);
-              const matchingSchedule = filteredSchedules.find(
-                (schedule) => schedule.raidName === raidName
-              );
+              const key = `${character.characterName}|${raidName}`;
+              const matchingSchedule = scheduleMap.get(key);
 
               return (
                 <RaidItem
@@ -188,9 +183,7 @@ const TodoWeekRaid: FC<Props> = ({ character, friend }) => {
       </Wrapper>
 
       <EditModal
-        onClose={() => {
-          setEditModal(false);
-        }}
+        onClose={() => setEditModal(false)}
         isOpen={editModal}
         character={character}
         friend={friend}

--- a/src/core/apis/friend.api.ts
+++ b/src/core/apis/friend.api.ts
@@ -41,7 +41,7 @@ export const handleFriendRequest = ({
 };
 
 export const removeFriend = (friendId: number): Promise<NoDataResponse> => {
-  return mainAxios.delete(`/api/v1/friends/${friendId}`);
+  return mainAxios.delete(`/api/v1/friend/${friendId}`);
 };
 
 // 깐부 설정 변경
@@ -62,7 +62,7 @@ export const updateFriendSetting = ({
 // 깐부 순서 변경
 export const updateFriendSort = ({ friendIdList }: { friendIdList: number[] }) => {
   return mainAxios
-    .put("/api/v1/friends/sort", {
+    .put("/api/v1/friend/sort", {
       friendIdList,
     })
     .then((res) => res.data);

--- a/src/core/apis/schedule.api.ts
+++ b/src/core/apis/schedule.api.ts
@@ -45,12 +45,14 @@ export const updateSchedule = ({
   memo,
   time,
   date,
+  autoCheck,
 }: UpdateScheduleRequest): Promise<NoDataResponse> => {
   return mainAxios.patch(`/api/v1/schedule/${scheduleId}`, {
     dayOfWeek,
     memo,
     time,
     date,
+    autoCheck,
   });
 };
 

--- a/src/core/types/schedule.d.ts
+++ b/src/core/types/schedule.d.ts
@@ -17,6 +17,7 @@ export interface ScheduleItem {
   leaderScheduleId: number;
   leaderCharacterName: string;
   friendCharacterNames: string[];
+  autoCheck: boolean;
 }
 
 export interface GetScheduleMonthRequest {
@@ -42,6 +43,7 @@ export interface ScheduleDetail {
   friendList: ScheduleCharacter[] | null;
   leader: boolean;
   date?: string;
+  autoCheck: boolean;
 }
 
 export interface UpdateScheduleRequest {
@@ -50,6 +52,7 @@ export interface UpdateScheduleRequest {
   memo: string;
   time: string;
   date?: string;
+  autoCheck?: boolean;
 }
 
 export interface CreateScheduleRequest {
@@ -64,6 +67,7 @@ export interface CreateScheduleRequest {
   scheduleRaidCategory: ScheduleRaidCategory;
   time: string;
   date?: string;
+  autoCheck?: boolean;
 }
 
 export interface UpdateFriendsOfScheduleRequest {

--- a/src/pages/friend/FriendsIndex.tsx
+++ b/src/pages/friend/FriendsIndex.tsx
@@ -440,16 +440,14 @@ const FriendsIndex = () => {
       </TabContainer>
 
       <FriendsWrapper>
-        {activeTab === "raids" ? (
-          sortMode ? (
-            <FriendSort
-              friends={getFriends.data?.filter(
-                (friend) => friend.areWeFriend === "깐부"
-              )}
-            />
-          ) : (
-            renderRaidsByType()
-          )
+        {sortMode ? (
+          <FriendSort
+            friends={getFriends.data?.filter(
+              (friend) => friend.areWeFriend === "깐부"
+            )}
+          />
+        ) : activeTab === "raids" ? (
+          renderRaidsByType()
         ) : (
           <FriendsList>
             {getFriends.data

--- a/src/pages/schedule/components/FormModal.tsx
+++ b/src/pages/schedule/components/FormModal.tsx
@@ -12,6 +12,7 @@ import useUpdateFriendsOfSchedule from "@core/hooks/mutations/schedule/useUpdate
 import useUpdateSchedule from "@core/hooks/mutations/schedule/useUpdateSchedule";
 import useCharacters from "@core/hooks/queries/character/useCharacters";
 import useWeekRaidCategories from "@core/hooks/queries/content/useWeekRaidCategories";
+import { useSchedulesMonth } from "@core/hooks/queries/schedule";
 import useSchedule from "@core/hooks/queries/schedule/useSchedule";
 import type { FormOptions } from "@core/types/app";
 import type { WeekRaidCategoryItem } from "@core/types/content";
@@ -126,6 +127,7 @@ const FormModal = ({ isOpen, onClose, targetSchedule, month, year }: Props) => {
   );
   const getWeekRaidCategories = useWeekRaidCategories();
   const getCharacters = useCharacters();
+
   const createSchedule = useCreateSchedule({
     onSuccess: () => {
       toast.success("일정 등록이 완료되었습니다.");
@@ -135,6 +137,7 @@ const FormModal = ({ isOpen, onClose, targetSchedule, month, year }: Props) => {
       onClose();
     },
   });
+
   const updateSchedule = useUpdateSchedule({
     onSuccess: () => {
       toast.success("일정 수정이 완료되었습니다.");
@@ -144,6 +147,7 @@ const FormModal = ({ isOpen, onClose, targetSchedule, month, year }: Props) => {
       onClose();
     },
   });
+
   const deleteSchedule = useDeleteSchedule({
     onSuccess: () => {
       toast.success("일정 삭제가 완료되었습니다.");
@@ -153,6 +157,7 @@ const FormModal = ({ isOpen, onClose, targetSchedule, month, year }: Props) => {
       onClose();
     },
   });
+
   const updateFriendsOfSchedule = useUpdateFriendsOfSchedule({
     onSuccess: () => {
       toast.success("일정에 속한 깐부가 수정되었습니다.");
@@ -184,6 +189,7 @@ const FormModal = ({ isOpen, onClose, targetSchedule, month, year }: Props) => {
   );
   const [memo, setMemo] = useState("");
   const [selectedDate, setSelectedDate] = useState<Dayjs | undefined>();
+  const [autoCheck, setAutoCheck] = useState(false);
 
   useEffect(() => {
     // 팝업 닫을 시 초기화
@@ -200,6 +206,7 @@ const FormModal = ({ isOpen, onClose, targetSchedule, month, year }: Props) => {
       setFriendCharacterIdList([]);
       setMemo("");
       setSelectedDate(undefined);
+      setAutoCheck(true);
     }
   }, [isOpen]);
 
@@ -261,6 +268,7 @@ const FormModal = ({ isOpen, onClose, targetSchedule, month, year }: Props) => {
       setRepeatWeek(schedule.repeatWeek);
       setMemo(schedule.memo);
       setSelectedDate(dayjs(schedule.date || dayjs()));
+      setAutoCheck(schedule.autoCheck); // 기존 값 세팅
     }
   }, [
     getScheduleParams,
@@ -331,6 +339,7 @@ const FormModal = ({ isOpen, onClose, targetSchedule, month, year }: Props) => {
                 date: selectedDate
                   ? selectedDate.format("YYYY-MM-DD")
                   : undefined,
+                autoCheck,
               });
             } else {
               createSchedule.mutate({
@@ -364,6 +373,7 @@ const FormModal = ({ isOpen, onClose, targetSchedule, month, year }: Props) => {
                 date: selectedDate
                   ? selectedDate.format("YYYY-MM-DD")
                   : undefined,
+                autoCheck,
               });
             }
           }}
@@ -584,6 +594,12 @@ const FormModal = ({ isOpen, onClose, targetSchedule, month, year }: Props) => {
                       </Groups>
                     </>
                   )}
+
+                  <Group>
+                    <Checkbox onChange={setAutoCheck} checked={autoCheck}>
+                      자동 체크
+                    </Checkbox>
+                  </Group>
 
                   {scheduleCategory === "PARTY" &&
                     (() => {


### PR DESCRIPTION
1. 일정에서 A캐릭 a컨텐츠 일정을 체크하면 B, C 캐릭의 a 컨텐츠까지 모두 일정에 등록되는 문제 수정
2. 깐부 삭제, 순서 변경 작동안되는 문제 수정
3. 스케줄 자동체크 설정 값 추가